### PR TITLE
Add CLI enhancements: version, stamp-id, errors, warning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,11 +49,17 @@ pytest -m integration  # All integration tests
 
 ### CLI Usage
 ```bash
+# Check version
+swarm-prov-upload --version
+
 # Check backend health
 swarm-prov-upload health
 
 # Upload data (uses gateway by default)
 swarm-prov-upload upload --file /path/to/data.txt --std "PROV-STD-V1"
+
+# Upload with existing stamp (skips purchase)
+swarm-prov-upload upload --file /path/to/data.txt --stamp-id <existing_stamp_id>
 
 # Upload with local Bee backend
 swarm-prov-upload --backend local upload --file /path/to/data.txt

--- a/README.md
+++ b/README.md
@@ -13,11 +13,17 @@ and upload them to the Swarm decentralized storage network.
 # Install
 pip install -e .
 
+# Check version
+swarm-prov-upload --version
+
 # Check connectivity
 swarm-prov-upload health
 
 # Upload data
 swarm-prov-upload upload --file /path/to/data.txt
+
+# Upload with existing stamp (skip purchase)
+swarm-prov-upload upload --file /path/to/data.txt --stamp-id <existing_stamp_id>
 
 # Download and verify
 swarm-prov-upload download <swarm_hash> --output-dir ./downloads
@@ -117,6 +123,9 @@ pytest -m gateway
 ```bash
 # Upload data to Swarm
 swarm-prov-upload upload --file /path/to/data.txt --std "PROV-STD-V1" --verbose
+
+# Upload with existing stamp (cost savings, faster)
+swarm-prov-upload upload --file /path/to/data.txt --stamp-id <existing_stamp_id>
 
 # Download and verify data
 swarm-prov-upload download <swarm_hash> --output-dir ./downloads --verbose

--- a/swarm_provenance_uploader/__init__.py
+++ b/swarm_provenance_uploader/__init__.py
@@ -1,1 +1,3 @@
+"""Swarm Provenance Uploader - CLI toolkit for uploading data to Swarm."""
 
+__version__ = "0.1.0"

--- a/swarm_provenance_uploader/exceptions.py
+++ b/swarm_provenance_uploader/exceptions.py
@@ -1,0 +1,54 @@
+"""Custom exceptions for the Swarm Provenance CLI.
+
+Provides unified error handling across both gateway and local Bee backends.
+"""
+
+
+class ProvenanceError(Exception):
+    """Base exception for all provenance CLI errors."""
+    pass
+
+
+class ConnectionError(ProvenanceError):
+    """Failed to connect to backend (gateway or local Bee)."""
+    pass
+
+
+class StampNotFoundError(ProvenanceError):
+    """Stamp does not exist."""
+    pass
+
+
+class StampNotUsableError(ProvenanceError):
+    """Stamp exists but is not usable for uploads."""
+    pass
+
+
+class StampPurchaseError(ProvenanceError):
+    """Failed to purchase a new stamp."""
+    pass
+
+
+class UploadError(ProvenanceError):
+    """Failed to upload data to Swarm."""
+    pass
+
+
+class DownloadError(ProvenanceError):
+    """Failed to download data from Swarm."""
+    pass
+
+
+class DataNotFoundError(ProvenanceError):
+    """Requested data not found on Swarm."""
+    pass
+
+
+class ValidationError(ProvenanceError):
+    """Data validation failed (e.g., hash mismatch, invalid format)."""
+    pass
+
+
+class AuthenticationError(ProvenanceError):
+    """Authentication failed (for future API key support)."""
+    pass


### PR DESCRIPTION
## Summary

- Add `--version`/`-V` flag to show CLI version
- Add `--stamp-id` option to reuse existing stamps on upload (cost savings, faster uploads)
- Add `exceptions.py` with unified error handling hierarchy
- Add deprecation warning when using local backend (encourages gateway usage)

## Closes

Closes #8, closes #9, closes #10, closes #11

## Changes

### New Features

**--version flag (#9)**
```bash
swarm-prov-upload --version
# Output: swarm-prov-upload 0.1.0
```

**--stamp-id option (#8)**
```bash
# Reuse existing stamp instead of purchasing new one
swarm-prov-upload upload --file data.txt --stamp-id <existing_stamp_id>
```

**Local backend warning (#11)**
```
⚠️  Note: Local Bee backend is intended for development/testing.
   For production use, consider the gateway: --backend gateway
```

**Unified exceptions (#10)**
- `ProvenanceError` - Base exception
- `ConnectionError`, `StampNotFoundError`, `StampNotUsableError`
- `UploadError`, `DownloadError`, `DataNotFoundError`
- `ValidationError`, `AuthenticationError`

### Files Changed

- `swarm_provenance_uploader/__init__.py` - Add `__version__`
- `swarm_provenance_uploader/cli.py` - Add version callback, stamp-id option, warning
- `swarm_provenance_uploader/exceptions.py` - New unified exception hierarchy
- `tests/test_cli.py` - Add 6 new tests (53 total)
- `README.md`, `CLAUDE.md` - Documentation updates

## Test plan

- [x] All 58 tests pass (53 unit + 5 integration)
- [x] `--version` shows correct version
- [x] `--stamp-id` skips stamp purchase
- [x] Local backend shows warning
- [ ] Manual test: upload with existing stamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)