### PR TITLE
Add version management with git hash and fix documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,32 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Never mention "Claude" or AI tools in commit messages
 - Keep commit messages focused on what changed and why
 
+## Version Management
+
+**IMPORTANT**: Increment the version number with each change that modifies functionality.
+
+### Version Location
+- Primary: `swarm_provenance_uploader/__init__.py` (`__version__`)
+- Mirror: `pyproject.toml` (`version` field)
+
+Both files MUST be kept in sync.
+
+### Version Format
+Uses semantic versioning with optional git hash: `MAJOR.MINOR.PATCH[+git.SHORT_HASH]`
+
+- **Release versions**: `0.1.0`, `1.0.0` (clean semver for PyPI releases)
+- **Development versions**: `0.1.1+git.abc1234` (includes git hash for traceability)
+
+### When to Increment
+- **PATCH** (0.0.X): Bug fixes, documentation updates, minor improvements
+- **MINOR** (0.X.0): New features, new CLI commands, new API endpoints
+- **MAJOR** (X.0.0): Breaking changes, incompatible API changes
+
+### How to Update Version
+1. Update `__version__` in `swarm_provenance_uploader/__init__.py`
+2. Update `version` in `pyproject.toml`
+3. The git hash suffix is added automatically at runtime (see below)
+
 ## Project Overview
 
 The Swarm Provenance Uploader is a Python CLI toolkit that wraps provenance data files within metadata structures and uploads them to the Swarm decentralized storage network. It supports two backends:
@@ -89,7 +115,8 @@ The application follows a modular architecture with clear separation of concerns
    - `file_utils.py`: File I/O and encoding utilities
    - `metadata_builder.py`: Metadata construction
 3. **Data Models** (`models.py`): Pydantic v2 schemas for metadata and API responses
-4. **Configuration** (`config.py`): Environment-based configuration management
+4. **Exceptions** (`exceptions.py`): Custom exception hierarchy for unified error handling
+5. **Configuration** (`config.py`): Environment-based configuration management
 
 ### Backend Clients
 

--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ swarm_provenance_uploader/
 │   ├── __init__.py
 │   ├── cli.py
 │   ├── config.py
+│   ├── exceptions.py            # Custom exception classes
 │   ├── models.py
 │   └── core/
 │       ├── __init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swarm-provenance-uploader"
-version = "0.1.0"
+version = "0.1.1"
 description = "A CLI toolkit for wrapping data and uploading to Swarm."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/swarm_provenance_uploader/__init__.py
+++ b/swarm_provenance_uploader/__init__.py
@@ -1,3 +1,37 @@
 """Swarm Provenance Uploader - CLI toolkit for uploading data to Swarm."""
 
-__version__ = "0.1.0"
+import subprocess
+from pathlib import Path
+
+__version_base__ = "0.1.1"
+
+
+def _get_git_hash() -> str:
+    """Get short git commit hash if available."""
+    try:
+        # Get the directory where this package is installed
+        package_dir = Path(__file__).parent.parent
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=package_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        pass
+    return ""
+
+
+def get_version() -> str:
+    """Get full version string with git hash if available."""
+    git_hash = _get_git_hash()
+    if git_hash:
+        return f"{__version_base__}+git.{git_hash}"
+    return __version_base__
+
+
+# For compatibility with tools that expect __version__
+__version__ = get_version()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -524,7 +524,8 @@ class TestVersionFlag:
 
         assert result.exit_code == 0
         assert "swarm-prov-upload" in result.stdout
-        assert "0.1.0" in result.stdout
+        # Version format: 0.1.1 or 0.1.1+git.abc1234
+        assert "0.1.1" in result.stdout
 
     def test_version_short_flag(self):
         """Tests -V flag shows version."""
@@ -532,7 +533,8 @@ class TestVersionFlag:
 
         assert result.exit_code == 0
         assert "swarm-prov-upload" in result.stdout
-        assert "0.1.0" in result.stdout
+        # Version format: 0.1.1 or 0.1.1+git.abc1234
+        assert "0.1.1" in result.stdout
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Add version management instructions to CLAUDE.md
- Implement automatic git hash suffix in version (e.g., `0.1.1+git.abc1234`)
- Add `exceptions.py` to directory structure in README and CLAUDE.md
- Bump version to 0.1.1

## Changes
- **Version now includes git hash**: `swarm-prov-upload --version` shows `0.1.1+git.<hash>`
- **Documentation**: Added missing `exceptions.py` module to architecture docs
- **CLAUDE.md**: Added version management guidelines for future development

## Test plan
- [x] All unit tests pass
- [x] `swarm-prov-upload --version` shows version with git hash