### PR TITLE
Fix stamp usability check for gateway API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Never use `upstream` for issues, PRs, or any GitHub operations
 - When running `gh` commands, always specify `--repo datafund/swarm_provenance_CLI`
 
-## Git Commits
+## Git Workflow
 
+**IMPORTANT**: Always create a feature branch before making changes. Never commit directly to `main`.
+
+### Branch Naming
+- `fix/` - Bug fixes (e.g., `fix/stamp-usability-check`)
+- `feature/` - New features (e.g., `feature/add-stamp-purchase-command`)
+- `docs/` - Documentation only (e.g., `docs/update-readme`)
+
+### Commit Messages
 - Never mention "Claude" or AI tools in commit messages
 - Keep commit messages focused on what changed and why
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swarm-provenance-uploader"
-version = "0.1.1"
+version = "0.1.2"
 description = "A CLI toolkit for wrapping data and uploading to Swarm."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/swarm_provenance_uploader/__init__.py
+++ b/swarm_provenance_uploader/__init__.py
@@ -3,7 +3,7 @@
 import subprocess
 from pathlib import Path
 
-__version_base__ = "0.1.1"
+__version_base__ = "0.1.2"
 
 
 def _get_git_hash() -> str:

--- a/swarm_provenance_uploader/cli.py
+++ b/swarm_provenance_uploader/cli.py
@@ -188,7 +188,7 @@ def upload(
                 stamp_info = swarm_client.get_stamp_info(local_bee_url, stamp_id, verbose=verbose)
 
             if stamp_info:
-                exists = stamp_info.get("exists", False)
+                exists = stamp_info.get("exists")
                 usable = stamp_info.get("usable", False)
                 batch_ttl_seconds = stamp_info.get("batchTTL")  # TTL in seconds
 
@@ -196,7 +196,8 @@ def upload(
                     ttl_str = f"{batch_ttl_seconds // 60}m {batch_ttl_seconds % 60}s" if batch_ttl_seconds is not None else "N/A"
                     typer.echo(f"    Attempt {i+1}: Stamp found - Exists={exists}, Usable={usable}, TTL={ttl_str}")
 
-                if exists and usable:
+                # Check usable flag - exists may be None from gateway API
+                if usable:
                     stamp_is_ready_for_upload = True
                     if not verbose: typer.echo(typer.style("OK", fg=typer.colors.GREEN))
                     else: typer.secho(f"    Stamp {stamp_id.lower()} is now USABLE!", fg=typer.colors.GREEN)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -524,8 +524,8 @@ class TestVersionFlag:
 
         assert result.exit_code == 0
         assert "swarm-prov-upload" in result.stdout
-        # Version format: 0.1.1 or 0.1.1+git.abc1234
-        assert "0.1.1" in result.stdout
+        # Version format: 0.1.2 or 0.1.2+git.abc1234
+        assert "0.1.2" in result.stdout
 
     def test_version_short_flag(self):
         """Tests -V flag shows version."""
@@ -533,8 +533,8 @@ class TestVersionFlag:
 
         assert result.exit_code == 0
         assert "swarm-prov-upload" in result.stdout
-        # Version format: 0.1.1 or 0.1.1+git.abc1234
-        assert "0.1.1" in result.stdout
+        # Version format: 0.1.2 or 0.1.2+git.abc1234
+        assert "0.1.2" in result.stdout
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Fix bug where stamps with `exists=None` but `usable=True` were not recognized as usable
- Add git workflow instructions to CLAUDE.md (always use branches)
- Bump version to 0.1.2

## Problem
The gateway API returns `exists: null` but `usable: true` for valid stamps. The previous check `if exists and usable` failed because `None` is falsy in Python, causing the upload loop to continue indefinitely even when the stamp was ready.

## Solution
Changed to check only the `usable` flag, which is the actual indicator for upload readiness.

## Test plan
- [x] All unit tests pass
- [x] Successfully uploaded test file to Swarm with new stamp
- [x] Swarm reference: `44f45a05753eff129c2e1f587788fbef4b97051525e5f6aba059ab85a7cdd268`