### PR TITLE
Add duration-based stamp purchases for gateway API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,7 @@ BEE_GATEWAY_URL=http://localhost:1633
 
 # Default Postage Stamp Parameters
 DEFAULT_POSTAGE_DEPTH=17
+# Duration in hours for stamp validity (gateway only, min 24)
+DEFAULT_POSTAGE_DURATION_HOURS=25
+# Legacy: PLUR amount (for local backend)
 DEFAULT_POSTAGE_AMOUNT=1000000000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,14 +89,20 @@ swarm-prov-upload --version
 # Check backend health
 swarm-prov-upload health
 
-# Upload data (uses gateway by default)
+# Upload data (uses gateway by default, 25 hour stamp validity)
 swarm-prov-upload upload --file /path/to/data.txt --std "PROV-STD-V1"
+
+# Upload with custom duration (hours, min 24)
+swarm-prov-upload upload --file /path/to/data.txt --duration 168  # 7 days
+
+# Upload with size preset
+swarm-prov-upload upload --file /path/to/data.txt --size medium
 
 # Upload with existing stamp (skips purchase)
 swarm-prov-upload upload --file /path/to/data.txt --stamp-id <existing_stamp_id>
 
-# Upload with local Bee backend
-swarm-prov-upload --backend local upload --file /path/to/data.txt
+# Upload with local Bee backend (uses legacy amount)
+swarm-prov-upload --backend local upload --file /path/to/data.txt --amount 1000000000
 
 # Download and verify data
 swarm-prov-upload download <swarm_hash> --output-dir ./downloads
@@ -181,7 +187,8 @@ Uses python-dotenv for environment configuration:
 
 **Stamp Defaults**:
 - `DEFAULT_POSTAGE_DEPTH`: Stamp depth parameter (default: 17)
-- `DEFAULT_POSTAGE_AMOUNT`: Stamp amount parameter (default: 1000000000)
+- `DEFAULT_POSTAGE_DURATION_HOURS`: Stamp validity in hours (gateway only, default: 25)
+- `DEFAULT_POSTAGE_AMOUNT`: Legacy PLUR amount for local backend (default: 1000000000)
 
 ## Testing Approach
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,14 @@ swarm-prov-upload --version
 # Check connectivity
 swarm-prov-upload health
 
-# Upload data
+# Upload data (purchases stamp with 25 hour validity)
 swarm-prov-upload upload --file /path/to/data.txt
+
+# Upload with custom duration (hours)
+swarm-prov-upload upload --file /path/to/data.txt --duration 48
+
+# Upload with size preset (small, medium, large)
+swarm-prov-upload upload --file /path/to/data.txt --size medium
 
 # Upload with existing stamp (skip purchase)
 swarm-prov-upload upload --file /path/to/data.txt --stamp-id <existing_stamp_id>
@@ -80,7 +86,8 @@ PROVENANCE_BACKEND=gateway           # gateway (default) or local
 PROVENANCE_GATEWAY_URL=https://provenance-gateway.datafund.io
 BEE_GATEWAY_URL=http://localhost:1633
 DEFAULT_POSTAGE_DEPTH=17
-DEFAULT_POSTAGE_AMOUNT=1000000000
+DEFAULT_POSTAGE_DURATION_HOURS=25    # Stamp validity in hours (gateway only, min 24)
+DEFAULT_POSTAGE_AMOUNT=1000000000    # Legacy: for local backend
 ```
 
 ## Run Tests
@@ -121,8 +128,14 @@ pytest -m gateway
 ### Data Operations
 
 ```bash
-# Upload data to Swarm
+# Upload data to Swarm (default: 25 hour stamp validity)
 swarm-prov-upload upload --file /path/to/data.txt --std "PROV-STD-V1" --verbose
+
+# Upload with custom duration (hours, min 24)
+swarm-prov-upload upload --file /path/to/data.txt --duration 168  # 7 days
+
+# Upload with size preset (small, medium, large)
+swarm-prov-upload upload --file /path/to/data.txt --size large
 
 # Upload with existing stamp (cost savings, faster)
 swarm-prov-upload upload --file /path/to/data.txt --stamp-id <existing_stamp_id>
@@ -130,6 +143,15 @@ swarm-prov-upload upload --file /path/to/data.txt --stamp-id <existing_stamp_id>
 # Download and verify data
 swarm-prov-upload download <swarm_hash> --output-dir ./downloads --verbose
 ```
+
+**Upload Options:**
+| Option | Description |
+|--------|-------------|
+| `--duration`, `-d` | Stamp validity in hours (min 24, gateway only) |
+| `--size` | Size preset: `small`, `medium`, `large` (gateway only) |
+| `--depth` | Technical depth parameter (16-32) |
+| `--stamp-id`, `-s` | Use existing stamp (skip purchase) |
+| `--amount` | Legacy: PLUR amount (local backend) |
 
 ### Stamp Management (Gateway only)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swarm-provenance-uploader"
-version = "0.1.2"
+version = "0.2.0"
 description = "A CLI toolkit for wrapping data and uploading to Swarm."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/swarm_provenance_uploader/__init__.py
+++ b/swarm_provenance_uploader/__init__.py
@@ -3,7 +3,7 @@
 import subprocess
 from pathlib import Path
 
-__version_base__ = "0.1.2"
+__version_base__ = "0.2.0"
 
 
 def _get_git_hash() -> str:

--- a/swarm_provenance_uploader/config.py
+++ b/swarm_provenance_uploader/config.py
@@ -7,7 +7,8 @@ load_dotenv()  # Load variables from .env file
 GATEWAY_DEFAULT_URL = "https://provenance-gateway.datafund.io"
 BEE_DEFAULT_URL = "http://localhost:1633"
 DEFAULT_DEPTH = 17
-DEFAULT_AMOUNT = 1000000000
+DEFAULT_DURATION_HOURS = 25  # Minimum 24 hours required by gateway
+DEFAULT_AMOUNT = 1000000000  # Legacy: kept for local Bee backend
 DEFAULT_BACKEND = "gateway"  # "gateway" or "local"
 
 # --- Backend Configuration ---
@@ -23,6 +24,12 @@ try:
 except (ValueError, TypeError):
     DEFAULT_POSTAGE_DEPTH = DEFAULT_DEPTH
 
+try:
+    DEFAULT_POSTAGE_DURATION_HOURS = int(os.getenv("DEFAULT_POSTAGE_DURATION_HOURS", str(DEFAULT_DURATION_HOURS)))
+except (ValueError, TypeError):
+    DEFAULT_POSTAGE_DURATION_HOURS = DEFAULT_DURATION_HOURS
+
+# Legacy: kept for local Bee backend compatibility
 try:
     DEFAULT_POSTAGE_AMOUNT = int(os.getenv("DEFAULT_POSTAGE_AMOUNT", str(DEFAULT_AMOUNT)))
 except (ValueError, TypeError):

--- a/swarm_provenance_uploader/core/gateway_client.py
+++ b/swarm_provenance_uploader/core/gateway_client.py
@@ -99,24 +99,50 @@ class GatewayClient:
             raise ConnectionError(f"Failed to list stamps: {e}") from e
 
     def purchase_stamp(
-        self, amount: int, depth: int, label: Optional[str] = None, verbose: bool = False
+        self,
+        duration_hours: Optional[int] = None,
+        size: Optional[str] = None,
+        depth: Optional[int] = None,
+        label: Optional[str] = None,
+        amount: Optional[int] = None,
+        verbose: bool = False
     ) -> str:
         """
         Purchase a new postage stamp.
 
         Args:
-            amount: Amount of BZZ to fund the stamp
-            depth: Depth of the stamp (determines capacity)
+            duration_hours: Hours of validity (min 24, default 25)
+            size: Preset size - 'small', 'medium', or 'large'
+            depth: Technical depth parameter (16-32)
             label: Optional label for the stamp
+            amount: Legacy - PLUR amount (use duration_hours instead)
             verbose: Enable debug output
 
         Returns:
             The batch ID (stamp ID) of the newly created stamp.
         """
         url = self._make_url("/api/v1/stamps/")
-        payload = {"amount": amount, "depth": depth}
-        if label:
+        payload = {}
+
+        # New duration-based parameter (preferred)
+        if duration_hours is not None:
+            payload["duration_hours"] = duration_hours
+
+        # Size preset
+        if size is not None:
+            payload["size"] = size
+
+        # Depth parameter
+        if depth is not None:
+            payload["depth"] = depth
+
+        # Label
+        if label is not None:
             payload["label"] = label
+
+        # Legacy amount (for backwards compatibility)
+        if amount is not None:
+            payload["amount"] = amount
 
         if verbose:
             print(f"--- DEBUG: Purchase Stamp ---")

--- a/swarm_provenance_uploader/models.py
+++ b/swarm_provenance_uploader/models.py
@@ -42,10 +42,12 @@ class StampListResponse(BaseModel):
 
 
 class StampPurchaseRequest(BaseModel):
-    """Request body for purchasing a new stamp."""
-    amount: int = Field(description="Amount of BZZ to fund the stamp")
-    depth: int = Field(description="Depth of the stamp (determines capacity)")
+    """Request body for purchasing a new stamp (gateway API)."""
+    duration_hours: Optional[int] = Field(default=None, ge=24, description="Hours of validity (min 24, default 25)")
+    size: Optional[str] = Field(default=None, description="Preset size: 'small', 'medium', or 'large'")
+    depth: Optional[int] = Field(default=None, ge=16, le=32, description="Technical depth parameter (16-32)")
     label: Optional[str] = Field(default=None, description="Optional label for the stamp")
+    amount: Optional[int] = Field(default=None, description="Legacy: PLUR amount (use duration_hours instead)")
 
 
 class StampPurchaseResponse(BaseModel):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from swarm_provenance_uploader.models import (
 runner = CliRunner()
 
 # Test constants
-DUMMY_HASH = "a028d9370473556397e189567c07279195890a16886002103369966898407152"
+DUMMY_HASH = "a028d9370473556397e189567c07279195890a1688600210336996689840.2.0"
 DUMMY_STAMP = "a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3"
 DUMMY_SWARM_REF = "b5d4ea763a1396676771151158461f73678f1676166acd06a0a18600b85de8a4"
 
@@ -524,8 +524,8 @@ class TestVersionFlag:
 
         assert result.exit_code == 0
         assert "swarm-prov-upload" in result.stdout
-        # Version format: 0.1.2 or 0.1.2+git.abc1234
-        assert "0.1.2" in result.stdout
+        # Version format: 0.2.0 or 0.2.0+git.abc1234
+        assert "0.2.0" in result.stdout
 
     def test_version_short_flag(self):
         """Tests -V flag shows version."""
@@ -533,8 +533,8 @@ class TestVersionFlag:
 
         assert result.exit_code == 0
         assert "swarm-prov-upload" in result.stdout
-        # Version format: 0.1.2 or 0.1.2+git.abc1234
-        assert "0.1.2" in result.stdout
+        # Version format: 0.2.0 or 0.2.0+git.abc1234
+        assert "0.2.0" in result.stdout
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Add duration-based stamp purchases using `duration_hours` parameter
- Add size preset option (`small`, `medium`, `large`)
- Bump version to 0.2.0

## New Upload Options (Gateway Only)
| Option | Description |
|--------|-------------|
| `--duration`, `-d` | Stamp validity in hours (min 24, default 25) |
| `--size` | Size preset: `small`, `medium`, `large` |
| `--depth` | Technical depth parameter (16-32) |

## Examples
```bash
# Default (25 hour stamp)
swarm-prov-upload upload --file data.txt

# Custom duration (7 days)
swarm-prov-upload upload --file data.txt --duration 168

# Size preset
swarm-prov-upload upload --file data.txt --size medium
```

## Breaking Changes
- Gateway uploads now use `duration_hours` instead of `amount` by default
- `--amount` option renamed from `--stamp-amount` but still works as fallback

## Backwards Compatibility
- Local backend (`--backend local`) still uses `--amount` and `--depth`
- Gateway accepts legacy `amount` parameter as fallback

## Test Plan
- [x] All 55 unit tests pass
- [x] Successfully uploaded file with `--duration 25` to live gateway
- [x] Swarm reference: `b4a5fdde8579635e1152d5fc81fc1ed7cdffe1bf6f8fedd420b857a12b2b0385`