### PR TITLE
Add core x402 payment module (#37)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swarm-provenance-uploader"
-version = "0.2.0"
+version = "0.3.0"
 description = "A CLI toolkit for wrapping data and uploading to Swarm."
 readme = "README.md"
 requires-python = ">=3.8"
@@ -30,6 +30,12 @@ testing = [
     "pytest>=7.4",
     "pytest-mock>=3.12",
     "requests-mock>=1.11"
+]
+# x402 payment support (USDC on Base chain)
+x402 = [
+    "x402>=0.1.0",
+    "eth-account>=0.8.0",
+    "web3>=6.0.0",
 ]
 
 [tool.pytest.ini_options]

--- a/swarm_provenance_uploader/__init__.py
+++ b/swarm_provenance_uploader/__init__.py
@@ -3,7 +3,7 @@
 import subprocess
 from pathlib import Path
 
-__version_base__ = "0.2.0"
+__version_base__ = "0.3.0"
 
 
 def _get_git_hash() -> str:

--- a/swarm_provenance_uploader/config.py
+++ b/swarm_provenance_uploader/config.py
@@ -34,3 +34,26 @@ try:
     DEFAULT_POSTAGE_AMOUNT = int(os.getenv("DEFAULT_POSTAGE_AMOUNT", str(DEFAULT_AMOUNT)))
 except (ValueError, TypeError):
     DEFAULT_POSTAGE_AMOUNT = DEFAULT_AMOUNT
+
+# --- x402 Payment Configuration ---
+# Enable x402 pay-per-request mode (disabled by default)
+X402_ENABLED = os.getenv("X402_ENABLED", "false").lower() == "true"
+
+# Environment variable name that contains the private key
+# The actual private key should be in this env var, not in config
+X402_PRIVATE_KEY_ENV = os.getenv("X402_PRIVATE_KEY_ENV", "SWARM_X402_PRIVATE_KEY")
+
+# Network: "base-sepolia" (testnet, default) or "base" (mainnet)
+X402_NETWORK = os.getenv("X402_NETWORK", "base-sepolia")
+
+# Auto-pay without prompting (disabled by default for safety)
+X402_AUTO_PAY = os.getenv("X402_AUTO_PAY", "false").lower() == "true"
+
+# Maximum auto-pay amount per request in USD (default: $1.00)
+try:
+    X402_MAX_AUTO_PAY_USD = float(os.getenv("X402_MAX_AUTO_PAY_USD", "1.00"))
+except (ValueError, TypeError):
+    X402_MAX_AUTO_PAY_USD = 1.00
+
+# Custom RPC URL (optional, uses default if not set)
+X402_RPC_URL = os.getenv("X402_RPC_URL")

--- a/swarm_provenance_uploader/core/x402_client.py
+++ b/swarm_provenance_uploader/core/x402_client.py
@@ -1,0 +1,419 @@
+"""
+x402 Payment Client for pay-per-request API access.
+
+This module handles x402 protocol payments using USDC on Base chain.
+It parses 402 responses, signs payment authorizations using EIP-712,
+and constructs the X-PAYMENT header for retrying requests.
+
+Requires optional dependencies: pip install swarm-provenance-uploader[x402]
+"""
+
+import base64
+import json
+import os
+import secrets
+import time
+from typing import Optional, Tuple
+
+from ..exceptions import (
+    InsufficientBalanceError,
+    PaymentRejectedError,
+    PaymentRequiredError,
+    X402ConfigurationError,
+    X402NetworkError,
+)
+from ..models import (
+    X402PaymentOption,
+    X402PaymentPayload,
+    X402PaymentRequirements,
+)
+
+# Lazy imports for optional x402 dependencies
+_eth_account = None
+_web3 = None
+
+
+def _import_x402_deps():
+    """Lazily import x402 dependencies to avoid import errors when not installed."""
+    global _eth_account, _web3
+    if _eth_account is None:
+        try:
+            from eth_account import Account as _eth_account_module
+            from eth_account.messages import encode_typed_data
+            from web3 import Web3 as _web3_module
+            _eth_account = _eth_account_module
+            _web3 = _web3_module
+        except ImportError as e:
+            raise X402ConfigurationError(
+                "x402 dependencies not installed. Run: pip install swarm-provenance-uploader[x402]"
+            ) from e
+    return _eth_account, _web3
+
+
+# USDC contract addresses by network
+USDC_CONTRACTS = {
+    "base-sepolia": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    "base": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+}
+
+# Default RPC endpoints
+RPC_ENDPOINTS = {
+    "base-sepolia": "https://sepolia.base.org",
+    "base": "https://mainnet.base.org",
+}
+
+# EIP-712 domain for USDC permit
+USDC_PERMIT_DOMAIN = {
+    "base-sepolia": {
+        "name": "USD Coin",
+        "version": "2",
+        "chainId": 84532,
+        "verifyingContract": USDC_CONTRACTS["base-sepolia"],
+    },
+    "base": {
+        "name": "USD Coin",
+        "version": "2",
+        "chainId": 8453,
+        "verifyingContract": USDC_CONTRACTS["base"],
+    },
+}
+
+
+class X402Client:
+    """
+    Client for handling x402 pay-per-request payments.
+
+    This client:
+    - Parses HTTP 402 responses to extract payment requirements
+    - Signs payment authorizations using EIP-712 typed data
+    - Constructs the X-PAYMENT header for authenticated requests
+    - Checks wallet USDC balance
+    """
+
+    SUPPORTED_NETWORKS = ["base-sepolia", "base"]
+
+    def __init__(
+        self,
+        private_key: Optional[str] = None,
+        network: str = "base-sepolia",
+        rpc_url: Optional[str] = None,
+    ):
+        """
+        Initialize the x402 payment client.
+
+        Args:
+            private_key: Ethereum private key for signing payments.
+                         If None, reads from X402_PRIVATE_KEY env var.
+            network: Network to use ('base-sepolia' or 'base').
+            rpc_url: Custom RPC URL. If None, uses default for network.
+
+        Raises:
+            X402ConfigurationError: If private key is missing or invalid.
+            X402NetworkError: If network is not supported.
+        """
+        # Import dependencies
+        Account, Web3 = _import_x402_deps()
+
+        # Validate network
+        if network not in self.SUPPORTED_NETWORKS:
+            raise X402NetworkError(
+                f"Unsupported network: {network}. Supported: {self.SUPPORTED_NETWORKS}",
+                expected=", ".join(self.SUPPORTED_NETWORKS),
+                actual=network,
+            )
+        self.network = network
+
+        # Get private key
+        self._private_key = private_key or os.getenv("X402_PRIVATE_KEY") or os.getenv("SWARM_X402_PRIVATE_KEY")
+        if not self._private_key:
+            raise X402ConfigurationError(
+                "x402 private key not configured. Set X402_PRIVATE_KEY or SWARM_X402_PRIVATE_KEY environment variable."
+            )
+
+        # Validate and derive address
+        try:
+            if not self._private_key.startswith("0x"):
+                self._private_key = "0x" + self._private_key
+            self._account = Account.from_key(self._private_key)
+            self.address = self._account.address
+        except Exception as e:
+            raise X402ConfigurationError(f"Invalid private key: {e}") from e
+
+        # Setup Web3 connection
+        self._rpc_url = rpc_url or RPC_ENDPOINTS.get(network)
+        self._web3 = Web3(Web3.HTTPProvider(self._rpc_url))
+
+        # USDC contract address for this network
+        self._usdc_address = USDC_CONTRACTS.get(network)
+
+    @property
+    def wallet_address(self) -> str:
+        """Get the wallet address derived from the private key."""
+        return self.address
+
+    def parse_402_response(self, response_body: dict) -> X402PaymentRequirements:
+        """
+        Parse an HTTP 402 response body to extract payment requirements.
+
+        Args:
+            response_body: The JSON body from a 402 response.
+
+        Returns:
+            X402PaymentRequirements with accepted payment options.
+
+        Raises:
+            PaymentRequiredError: If response format is invalid.
+        """
+        try:
+            return X402PaymentRequirements.model_validate(response_body)
+        except Exception as e:
+            raise PaymentRequiredError(
+                f"Failed to parse 402 response: {e}",
+                payment_options=[],
+            ) from e
+
+    def select_payment_option(
+        self, requirements: X402PaymentRequirements
+    ) -> X402PaymentOption:
+        """
+        Select a compatible payment option from requirements.
+
+        Prefers options matching the configured network.
+
+        Args:
+            requirements: Payment requirements from 402 response.
+
+        Returns:
+            The selected payment option.
+
+        Raises:
+            PaymentRequiredError: If no compatible option found.
+        """
+        # Filter for matching network
+        compatible = [
+            opt for opt in requirements.accepts
+            if opt.network == self.network
+        ]
+
+        if not compatible:
+            available_networks = [opt.network for opt in requirements.accepts]
+            raise X402NetworkError(
+                f"No payment options for network '{self.network}'. "
+                f"Available: {available_networks}",
+                expected=self.network,
+                actual=", ".join(available_networks),
+            )
+
+        # Prefer 'exact' scheme if available
+        exact_options = [opt for opt in compatible if opt.scheme == "exact"]
+        if exact_options:
+            return exact_options[0]
+
+        return compatible[0]
+
+    def get_usdc_balance(self) -> Tuple[int, float]:
+        """
+        Get USDC balance for the configured wallet.
+
+        Returns:
+            Tuple of (raw_balance_smallest_units, balance_in_usdc).
+
+        Raises:
+            X402ConfigurationError: If balance check fails.
+        """
+        # USDC ERC-20 balanceOf ABI
+        balance_of_abi = [
+            {
+                "constant": True,
+                "inputs": [{"name": "_owner", "type": "address"}],
+                "name": "balanceOf",
+                "outputs": [{"name": "balance", "type": "uint256"}],
+                "type": "function",
+            }
+        ]
+
+        try:
+            contract = self._web3.eth.contract(
+                address=self._web3.to_checksum_address(self._usdc_address),
+                abi=balance_of_abi,
+            )
+            raw_balance = contract.functions.balanceOf(self.address).call()
+            usdc_balance = raw_balance / 1_000_000  # USDC has 6 decimals
+            return raw_balance, usdc_balance
+        except Exception as e:
+            raise X402ConfigurationError(f"Failed to check USDC balance: {e}") from e
+
+    def check_balance_sufficient(self, required_amount: str) -> bool:
+        """
+        Check if wallet has sufficient USDC for payment.
+
+        Args:
+            required_amount: Required amount in smallest units (string).
+
+        Returns:
+            True if balance is sufficient.
+
+        Raises:
+            InsufficientBalanceError: If balance is insufficient.
+        """
+        raw_balance, usdc_balance = self.get_usdc_balance()
+        required_int = int(required_amount)
+
+        if raw_balance < required_int:
+            required_usdc = required_int / 1_000_000
+            raise InsufficientBalanceError(
+                f"Insufficient USDC balance. Required: ${required_usdc:.6f}, "
+                f"Available: ${usdc_balance:.6f}",
+                required=str(required_int),
+                available=str(raw_balance),
+            )
+        return True
+
+    def _generate_nonce(self) -> str:
+        """Generate a random nonce for payment authorization."""
+        return "0x" + secrets.token_hex(32)
+
+    def sign_payment(
+        self,
+        payment_option: X402PaymentOption,
+        timeout_seconds: int = 300,
+    ) -> str:
+        """
+        Sign a payment authorization using EIP-712.
+
+        Args:
+            payment_option: The selected payment option.
+            timeout_seconds: Payment validity window in seconds.
+
+        Returns:
+            Base64-encoded X-PAYMENT header value.
+
+        Raises:
+            PaymentRejectedError: If signing fails.
+        """
+        from eth_account.messages import encode_typed_data
+
+        try:
+            # Generate authorization data
+            valid_before = int(time.time()) + timeout_seconds
+            nonce = self._generate_nonce()
+            amount = payment_option.maxAmountRequired
+
+            # Build EIP-712 typed data for USDC TransferWithAuthorization
+            domain = USDC_PERMIT_DOMAIN.get(self.network)
+            if not domain:
+                raise X402NetworkError(f"No EIP-712 domain for network: {self.network}")
+
+            typed_data = {
+                "types": {
+                    "EIP712Domain": [
+                        {"name": "name", "type": "string"},
+                        {"name": "version", "type": "string"},
+                        {"name": "chainId", "type": "uint256"},
+                        {"name": "verifyingContract", "type": "address"},
+                    ],
+                    "TransferWithAuthorization": [
+                        {"name": "from", "type": "address"},
+                        {"name": "to", "type": "address"},
+                        {"name": "value", "type": "uint256"},
+                        {"name": "validAfter", "type": "uint256"},
+                        {"name": "validBefore", "type": "uint256"},
+                        {"name": "nonce", "type": "bytes32"},
+                    ],
+                },
+                "primaryType": "TransferWithAuthorization",
+                "domain": domain,
+                "message": {
+                    "from": self.address,
+                    "to": payment_option.payTo,
+                    "value": int(amount),
+                    "validAfter": 0,
+                    "validBefore": valid_before,
+                    "nonce": nonce,
+                },
+            }
+
+            # Sign the typed data
+            signable = encode_typed_data(full_message=typed_data)
+            signed = self._account.sign_message(signable)
+
+            # Build the payment payload
+            payload = X402PaymentPayload(
+                x402Version=1,
+                scheme=payment_option.scheme,
+                network=self.network,
+                payload={
+                    "signature": signed.signature.hex(),
+                    "authorization": {
+                        "from": self.address,
+                        "to": payment_option.payTo,
+                        "value": amount,
+                        "validAfter": 0,
+                        "validBefore": valid_before,
+                        "nonce": nonce,
+                    },
+                },
+            )
+
+            # Encode as base64 for X-PAYMENT header
+            payload_json = payload.model_dump_json()
+            return base64.b64encode(payload_json.encode()).decode()
+
+        except Exception as e:
+            raise PaymentRejectedError(
+                f"Failed to sign payment: {e}",
+                reason=str(e),
+            ) from e
+
+    def create_payment_header(
+        self,
+        response_body: dict,
+        timeout_seconds: int = 300,
+        check_balance: bool = True,
+    ) -> str:
+        """
+        Create X-PAYMENT header from a 402 response.
+
+        This is the main entry point for handling 402 responses.
+        It parses requirements, selects an option, optionally checks
+        balance, and signs the payment.
+
+        Args:
+            response_body: The JSON body from a 402 response.
+            timeout_seconds: Payment validity window.
+            check_balance: Whether to verify USDC balance first.
+
+        Returns:
+            Base64-encoded value for X-PAYMENT header.
+
+        Raises:
+            PaymentRequiredError: If 402 response is invalid.
+            X402NetworkError: If no compatible network option.
+            InsufficientBalanceError: If balance check fails.
+            PaymentRejectedError: If signing fails.
+        """
+        # Parse the 402 response
+        requirements = self.parse_402_response(response_body)
+
+        # Select a compatible payment option
+        option = self.select_payment_option(requirements)
+
+        # Optionally check balance
+        if check_balance:
+            self.check_balance_sufficient(option.maxAmountRequired)
+
+        # Sign and return the payment header
+        return self.sign_payment(option, timeout_seconds)
+
+    def format_amount_usd(self, amount: str) -> str:
+        """
+        Format a USDC amount (in smallest units) as USD string.
+
+        Args:
+            amount: Amount in smallest units (6 decimals).
+
+        Returns:
+            Formatted string like "$0.05".
+        """
+        usdc = int(amount) / 1_000_000
+        return f"${usdc:.2f}"

--- a/swarm_provenance_uploader/exceptions.py
+++ b/swarm_provenance_uploader/exceptions.py
@@ -52,3 +52,49 @@ class ValidationError(ProvenanceError):
 class AuthenticationError(ProvenanceError):
     """Authentication failed (for future API key support)."""
     pass
+
+
+# --- x402 Payment Exceptions ---
+
+class X402Error(ProvenanceError):
+    """Base exception for x402 payment errors."""
+    pass
+
+
+class PaymentRequiredError(X402Error):
+    """HTTP 402 received but x402 payments not configured or disabled."""
+
+    def __init__(self, message: str, payment_options: list = None):
+        super().__init__(message)
+        self.payment_options = payment_options or []
+
+
+class InsufficientBalanceError(X402Error):
+    """Wallet USDC balance too low for required payment."""
+
+    def __init__(self, message: str, required: str = None, available: str = None):
+        super().__init__(message)
+        self.required = required
+        self.available = available
+
+
+class PaymentRejectedError(X402Error):
+    """Payment signature or amount rejected by x402 facilitator."""
+
+    def __init__(self, message: str, reason: str = None):
+        super().__init__(message)
+        self.reason = reason
+
+
+class X402ConfigurationError(X402Error):
+    """x402 configuration is invalid or incomplete."""
+    pass
+
+
+class X402NetworkError(X402Error):
+    """Network mismatch or unsupported network."""
+
+    def __init__(self, message: str, expected: str = None, actual: str = None):
+        super().__init__(message)
+        self.expected = expected
+        self.actual = actual

--- a/swarm_provenance_uploader/models.py
+++ b/swarm_provenance_uploader/models.py
@@ -92,3 +92,44 @@ class ChequebookResponse(BaseModel):
     chequebookAddress: str = Field(description="Chequebook contract address")
     availableBalance: str = Field(description="Available balance")
     totalBalance: str = Field(description="Total balance")
+
+
+# --- x402 Payment Models ---
+
+class X402PaymentOption(BaseModel):
+    """A single payment option from the 402 response accepts array."""
+    scheme: str = Field(description="Payment scheme (e.g., 'exact')")
+    network: str = Field(description="Network identifier (e.g., 'base-sepolia', 'base')")
+    maxAmountRequired: str = Field(description="Maximum payment amount in smallest units")
+    resource: str = Field(description="Resource being paid for")
+    description: Optional[str] = Field(default=None, description="Human-readable description")
+    mimeType: Optional[str] = Field(default=None, description="MIME type of resource")
+    payTo: str = Field(description="Address to pay to")
+    maxTimeoutSeconds: Optional[int] = Field(default=None, description="Max timeout for payment")
+    asset: Optional[str] = Field(default=None, description="Asset/token contract address")
+    extra: Optional[dict] = Field(default=None, description="Additional provider-specific data")
+
+
+class X402PaymentRequirements(BaseModel):
+    """Parsed from HTTP 402 response."""
+    accepts: List[X402PaymentOption] = Field(description="List of accepted payment options")
+    error: Optional[str] = Field(default=None, description="Error message if present")
+    x402Version: int = Field(default=1, description="x402 protocol version")
+
+
+class X402PaymentAuthorization(BaseModel):
+    """Authorization data for payment signature."""
+    from_address: str = Field(alias="from", description="Payer wallet address")
+    to: str = Field(description="Recipient address")
+    value: str = Field(description="Payment amount in smallest units")
+    validAfter: int = Field(default=0, description="Timestamp after which payment is valid")
+    validBefore: int = Field(description="Timestamp before which payment is valid")
+    nonce: str = Field(description="Unique nonce for this payment")
+
+
+class X402PaymentPayload(BaseModel):
+    """Payload for X-PAYMENT header."""
+    x402Version: int = Field(default=1, description="x402 protocol version")
+    scheme: str = Field(default="exact", description="Payment scheme")
+    network: str = Field(description="Network identifier")
+    payload: dict = Field(description="Contains signature and authorization data")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -524,8 +524,9 @@ class TestVersionFlag:
 
         assert result.exit_code == 0
         assert "swarm-prov-upload" in result.stdout
-        # Version format: 0.2.0 or 0.2.0+git.abc1234
-        assert "0.2.0" in result.stdout
+        # Version format: X.Y.Z or X.Y.Z+git.abc1234
+        import re
+        assert re.search(r"\d+\.\d+\.\d+", result.stdout)
 
     def test_version_short_flag(self):
         """Tests -V flag shows version."""
@@ -533,8 +534,9 @@ class TestVersionFlag:
 
         assert result.exit_code == 0
         assert "swarm-prov-upload" in result.stdout
-        # Version format: 0.2.0 or 0.2.0+git.abc1234
-        assert "0.2.0" in result.stdout
+        # Version format: X.Y.Z or X.Y.Z+git.abc1234
+        import re
+        assert re.search(r"\d+\.\d+\.\d+", result.stdout)
 
 
 # =============================================================================

--- a/tests/test_x402_client.py
+++ b/tests/test_x402_client.py
@@ -1,0 +1,423 @@
+"""Tests for the x402 payment client module."""
+
+import base64
+import json
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+from swarm_provenance_uploader.exceptions import (
+    InsufficientBalanceError,
+    PaymentRequiredError,
+    X402ConfigurationError,
+    X402NetworkError,
+)
+from swarm_provenance_uploader.models import (
+    X402PaymentOption,
+    X402PaymentRequirements,
+)
+
+
+# Test constants
+DUMMY_PRIVATE_KEY = "0x" + "a" * 64  # 32 bytes hex
+DUMMY_ADDRESS = "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00"
+DUMMY_PAY_TO = "0x1234567890AbcdEF1234567890aBcDeF12345678"
+
+
+# Sample 402 response
+SAMPLE_402_RESPONSE = {
+    "x402Version": 1,
+    "accepts": [
+        {
+            "scheme": "exact",
+            "network": "base-sepolia",
+            "maxAmountRequired": "50000",  # $0.05 USDC
+            "resource": "/api/v1/stamps/",
+            "description": "Stamp purchase",
+            "payTo": DUMMY_PAY_TO,
+            "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        }
+    ],
+}
+
+
+@pytest.fixture
+def mock_eth_deps():
+    """Mock eth-account and web3 dependencies."""
+    with patch.dict(os.environ, {"SWARM_X402_PRIVATE_KEY": DUMMY_PRIVATE_KEY}):
+        # Mock eth_account
+        mock_account = MagicMock()
+        mock_account.address = DUMMY_ADDRESS
+        mock_account.sign_message.return_value = MagicMock(
+            signature=MagicMock(hex=lambda: "0x" + "b" * 130)
+        )
+
+        mock_account_class = MagicMock()
+        mock_account_class.from_key.return_value = mock_account
+
+        # Mock web3
+        mock_web3_instance = MagicMock()
+        mock_contract = MagicMock()
+        mock_contract.functions.balanceOf.return_value.call.return_value = 10_000_000  # $10 USDC
+        mock_web3_instance.eth.contract.return_value = mock_contract
+        mock_web3_instance.to_checksum_address = lambda x: x
+
+        mock_web3_class = MagicMock(return_value=mock_web3_instance)
+        mock_web3_class.HTTPProvider = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "eth_account": MagicMock(Account=mock_account_class),
+                "eth_account.messages": MagicMock(encode_typed_data=MagicMock(return_value=b"typed_data")),
+                "web3": MagicMock(Web3=mock_web3_class),
+            },
+        ):
+            yield {
+                "account": mock_account,
+                "account_class": mock_account_class,
+                "web3_instance": mock_web3_instance,
+                "web3_class": mock_web3_class,
+                "contract": mock_contract,
+            }
+
+
+class TestX402ClientInit:
+    """Tests for X402Client initialization."""
+
+    def test_missing_private_key_raises_error(self, mock_eth_deps):
+        """Tests that missing private key raises configuration error."""
+        # Clear env vars and re-test
+        with patch.dict(os.environ, {}, clear=True):
+            from swarm_provenance_uploader.core.x402_client import X402Client
+
+            with pytest.raises(X402ConfigurationError) as exc_info:
+                X402Client()
+
+            assert "private key not configured" in str(exc_info.value).lower()
+
+    def test_unsupported_network_raises_error(self, mock_eth_deps):
+        """Tests that unsupported network raises error."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        with pytest.raises(X402NetworkError) as exc_info:
+            X402Client(network="ethereum-mainnet")
+
+        assert "unsupported network" in str(exc_info.value).lower()
+
+    def test_valid_init_with_env_key(self, mock_eth_deps):
+        """Tests successful initialization with env var key."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client()
+
+        assert client.address == DUMMY_ADDRESS
+        assert client.network == "base-sepolia"
+
+    def test_valid_init_with_provided_key(self, mock_eth_deps):
+        """Tests successful initialization with provided key."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client(private_key=DUMMY_PRIVATE_KEY)
+
+        assert client.address == DUMMY_ADDRESS
+
+    def test_network_selection(self, mock_eth_deps):
+        """Tests network can be specified."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client(network="base")
+
+        assert client.network == "base"
+
+
+class TestX402ClientParse402:
+    """Tests for parsing 402 responses."""
+
+    def test_parse_valid_402_response(self, mock_eth_deps):
+        """Tests parsing a valid 402 response."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client()
+        requirements = client.parse_402_response(SAMPLE_402_RESPONSE)
+
+        assert isinstance(requirements, X402PaymentRequirements)
+        assert len(requirements.accepts) == 1
+        assert requirements.accepts[0].network == "base-sepolia"
+        assert requirements.accepts[0].maxAmountRequired == "50000"
+
+    def test_parse_invalid_402_response(self, mock_eth_deps):
+        """Tests parsing an invalid 402 response raises error."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client()
+
+        with pytest.raises(PaymentRequiredError):
+            client.parse_402_response({"invalid": "data"})
+
+
+class TestX402ClientSelectPaymentOption:
+    """Tests for selecting payment options."""
+
+    def test_select_matching_network_option(self, mock_eth_deps):
+        """Tests selecting an option matching configured network."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client(network="base-sepolia")
+        requirements = X402PaymentRequirements(
+            accepts=[
+                X402PaymentOption(
+                    scheme="exact",
+                    network="base-sepolia",
+                    maxAmountRequired="50000",
+                    resource="/test",
+                    payTo=DUMMY_PAY_TO,
+                ),
+                X402PaymentOption(
+                    scheme="exact",
+                    network="base",
+                    maxAmountRequired="100000",
+                    resource="/test",
+                    payTo=DUMMY_PAY_TO,
+                ),
+            ]
+        )
+
+        option = client.select_payment_option(requirements)
+
+        assert option.network == "base-sepolia"
+        assert option.maxAmountRequired == "50000"
+
+    def test_no_matching_network_raises_error(self, mock_eth_deps):
+        """Tests that no matching network raises error."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client(network="base-sepolia")
+        requirements = X402PaymentRequirements(
+            accepts=[
+                X402PaymentOption(
+                    scheme="exact",
+                    network="base",  # Different network
+                    maxAmountRequired="50000",
+                    resource="/test",
+                    payTo=DUMMY_PAY_TO,
+                ),
+            ]
+        )
+
+        with pytest.raises(X402NetworkError) as exc_info:
+            client.select_payment_option(requirements)
+
+        assert "base-sepolia" in str(exc_info.value)
+
+    def test_prefers_exact_scheme(self, mock_eth_deps):
+        """Tests that 'exact' scheme is preferred."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client(network="base-sepolia")
+        requirements = X402PaymentRequirements(
+            accepts=[
+                X402PaymentOption(
+                    scheme="other",
+                    network="base-sepolia",
+                    maxAmountRequired="100000",
+                    resource="/test",
+                    payTo=DUMMY_PAY_TO,
+                ),
+                X402PaymentOption(
+                    scheme="exact",
+                    network="base-sepolia",
+                    maxAmountRequired="50000",
+                    resource="/test",
+                    payTo=DUMMY_PAY_TO,
+                ),
+            ]
+        )
+
+        option = client.select_payment_option(requirements)
+
+        assert option.scheme == "exact"
+
+
+class TestX402ClientBalance:
+    """Tests for balance checking."""
+
+    def test_get_balance_success(self, mock_eth_deps):
+        """Tests getting USDC balance."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client()
+        raw, usdc = client.get_usdc_balance()
+
+        assert raw == 10_000_000  # Raw units
+        assert usdc == 10.0  # USDC (6 decimals)
+
+    def test_balance_sufficient(self, mock_eth_deps):
+        """Tests balance check when sufficient."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client()
+        result = client.check_balance_sufficient("50000")  # $0.05
+
+        assert result is True
+
+    def test_balance_insufficient(self):
+        """Tests balance check when insufficient."""
+        with patch.dict(os.environ, {"SWARM_X402_PRIVATE_KEY": DUMMY_PRIVATE_KEY}):
+            # Mock eth_account
+            mock_account = MagicMock()
+            mock_account.address = DUMMY_ADDRESS
+
+            mock_account_class = MagicMock()
+            mock_account_class.from_key.return_value = mock_account
+
+            # Mock web3 with low balance
+            mock_web3_instance = MagicMock()
+            mock_contract = MagicMock()
+            mock_contract.functions.balanceOf.return_value.call.return_value = 10_000  # $0.01
+            mock_web3_instance.eth.contract.return_value = mock_contract
+            mock_web3_instance.to_checksum_address = lambda x: x
+
+            mock_web3_class = MagicMock(return_value=mock_web3_instance)
+            mock_web3_class.HTTPProvider = MagicMock()
+
+            with patch.dict(
+                "sys.modules",
+                {
+                    "eth_account": MagicMock(Account=mock_account_class),
+                    "eth_account.messages": MagicMock(encode_typed_data=MagicMock(return_value=b"typed_data")),
+                    "web3": MagicMock(Web3=mock_web3_class),
+                },
+            ):
+                # Force reimport to get new mocks
+                import importlib
+                import swarm_provenance_uploader.core.x402_client as x402_module
+                # Reset the lazy import globals
+                x402_module._eth_account = None
+                x402_module._web3 = None
+
+                from swarm_provenance_uploader.core.x402_client import X402Client
+
+                client = X402Client()
+
+                with pytest.raises(InsufficientBalanceError) as exc_info:
+                    client.check_balance_sufficient("50000")  # $0.05
+
+                assert exc_info.value.required == "50000"
+                assert exc_info.value.available == "10000"
+
+
+class TestX402ClientSignPayment:
+    """Tests for payment signing."""
+
+    def test_sign_payment_success(self, mock_eth_deps):
+        """Tests signing a payment."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client()
+        option = X402PaymentOption(
+            scheme="exact",
+            network="base-sepolia",
+            maxAmountRequired="50000",
+            resource="/test",
+            payTo=DUMMY_PAY_TO,
+        )
+
+        header = client.sign_payment(option)
+
+        # Verify it's base64 encoded
+        decoded = base64.b64decode(header)
+        payload = json.loads(decoded)
+
+        assert payload["x402Version"] == 1
+        assert payload["scheme"] == "exact"
+        assert payload["network"] == "base-sepolia"
+        assert "signature" in payload["payload"]
+        assert "authorization" in payload["payload"]
+
+
+class TestX402ClientCreatePaymentHeader:
+    """Tests for the main entry point."""
+
+    def test_create_payment_header_success(self, mock_eth_deps):
+        """Tests creating a complete payment header."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client()
+        header = client.create_payment_header(SAMPLE_402_RESPONSE)
+
+        # Verify it's valid base64
+        decoded = base64.b64decode(header)
+        payload = json.loads(decoded)
+
+        assert payload["x402Version"] == 1
+        assert "payload" in payload
+
+    def test_create_payment_header_with_balance_check(self, mock_eth_deps):
+        """Tests payment header creation with balance check enabled."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client()
+        header = client.create_payment_header(
+            SAMPLE_402_RESPONSE,
+            check_balance=True,
+        )
+
+        assert header is not None
+
+    def test_create_payment_header_insufficient_balance(self):
+        """Tests payment header creation fails with insufficient balance."""
+        with patch.dict(os.environ, {"SWARM_X402_PRIVATE_KEY": DUMMY_PRIVATE_KEY}):
+            # Mock eth_account
+            mock_account = MagicMock()
+            mock_account.address = DUMMY_ADDRESS
+
+            mock_account_class = MagicMock()
+            mock_account_class.from_key.return_value = mock_account
+
+            # Mock web3 with low balance
+            mock_web3_instance = MagicMock()
+            mock_contract = MagicMock()
+            mock_contract.functions.balanceOf.return_value.call.return_value = 10_000  # $0.01
+            mock_web3_instance.eth.contract.return_value = mock_contract
+            mock_web3_instance.to_checksum_address = lambda x: x
+
+            mock_web3_class = MagicMock(return_value=mock_web3_instance)
+            mock_web3_class.HTTPProvider = MagicMock()
+
+            with patch.dict(
+                "sys.modules",
+                {
+                    "eth_account": MagicMock(Account=mock_account_class),
+                    "eth_account.messages": MagicMock(encode_typed_data=MagicMock(return_value=b"typed_data")),
+                    "web3": MagicMock(Web3=mock_web3_class),
+                },
+            ):
+                # Force reimport to get new mocks
+                import swarm_provenance_uploader.core.x402_client as x402_module
+                x402_module._eth_account = None
+                x402_module._web3 = None
+
+                from swarm_provenance_uploader.core.x402_client import X402Client
+
+                client = X402Client()
+
+                with pytest.raises(InsufficientBalanceError):
+                    client.create_payment_header(
+                        SAMPLE_402_RESPONSE,
+                        check_balance=True,
+                    )
+
+
+class TestX402ClientFormatting:
+    """Tests for formatting utilities."""
+
+    def test_format_amount_usd(self, mock_eth_deps):
+        """Tests formatting amount as USD."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client()
+
+        assert client.format_amount_usd("50000") == "$0.05"
+        assert client.format_amount_usd("1000000") == "$1.00"
+        assert client.format_amount_usd("10000000") == "$10.00"


### PR DESCRIPTION
## Summary

Implements the core x402 payment client module for pay-per-request API access using USDC on Base chain.

Closes #37

## Changes

- **Dependencies**: Added optional x402 deps (`x402`, `eth-account`, `web3`) to pyproject.toml
- **Models**: Added `X402PaymentOption`, `X402PaymentRequirements`, `X402PaymentPayload` to models.py
- **Exceptions**: Added `PaymentRequiredError`, `InsufficientBalanceError`, `PaymentRejectedError`, `X402ConfigurationError`, `X402NetworkError`
- **Core Module**: Created `core/x402_client.py` with:
  - 402 response parsing
  - EIP-712 typed data signing for USDC TransferWithAuthorization
  - USDC balance checking via Web3
  - X-PAYMENT header construction (base64-encoded)
  - Support for both `base-sepolia` (testnet) and `base` (mainnet)
- **Config**: Added x402 configuration options to config.py
- **Tests**: 18 unit tests with mocked eth-account/web3 dependencies
- **Version**: Bumped to 0.3.0

## Test plan

- [x] All 73 unit tests pass
- [ ] Manual testing with testnet gateway (deferred to integration)

## Notes

This is the foundation module. GatewayClient integration (#38) will use this module to handle 402 responses automatically.