### PR TITLE
Add x402 CLI commands and configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,22 @@ DEFAULT_POSTAGE_DEPTH=17
 DEFAULT_POSTAGE_DURATION_HOURS=25
 # Legacy: PLUR amount (for local backend)
 DEFAULT_POSTAGE_AMOUNT=1000000000
+
+# --- x402 Payment Configuration (optional) ---
+# Enable x402 pay-per-request mode (USDC on Base chain)
+# X402_ENABLED=true
+
+# Your wallet private key (keep secret!)
+# SWARM_X402_PRIVATE_KEY=0x...
+
+# Network: "base-sepolia" (testnet, default) or "base" (mainnet)
+# X402_NETWORK=base-sepolia
+
+# Auto-pay without prompting (up to max limit)
+# X402_AUTO_PAY=false
+
+# Maximum auto-pay amount per request in USD
+# X402_MAX_AUTO_PAY_USD=1.00
+
+# Custom RPC URL (optional, uses default if not set)
+# X402_RPC_URL=


### PR DESCRIPTION
## Summary

- Add `x402` command group with `status`, `balance`, and `info` subcommands
- Add global x402 flags: `--x402`, `--auto-pay`, `--max-pay`, `--x402-network`
- Integrate x402 payment support into upload command with confirmation prompts
- Update .env.example with x402 configuration options
- Add 11 unit tests for CLI x402 functionality

Closes #39

## Test plan

- [x] All 91 tests pass
- [x] CLI help text displays correctly for new commands
- [x] Global flags properly update configuration
- [x] Payment confirmation callback works as expected