### PR TITLE
Add domain-specific examples: audit trail, scientific data, encrypted data, market memory

### DIFF
--- a/examples/02-audit-trail/README.md
+++ b/examples/02-audit-trail/README.md
@@ -1,0 +1,101 @@
+# Example 02: Audit Trail
+
+Demonstrates using Swarm as an immutable audit log for compliance records.
+
+## What This Demonstrates
+
+- Uploading multiple audit records with a provenance standard (`--std "AUDIT-LOG-V1"`)
+- Immutable storage of compliance-critical events
+- Downloading and verifying record integrity via SHA-256
+
+## Use Case
+
+Organizations subject to SOX, GDPR, or ISO 27001 need tamper-proof audit trails. By uploading audit events to Swarm with a provenance standard tag, each record gets:
+
+- An immutable content-addressed reference (Swarm hash)
+- A SHA-256 integrity fingerprint
+- A metadata envelope recording the provenance standard
+
+No one — not even the data owner — can alter a record after upload without changing its hash.
+
+## Prerequisites
+
+1. Install the CLI: `pip install -e .`
+2. Gateway access (default, no setup needed)
+
+## Quick Start
+
+### Shell
+
+```bash
+chmod +x demo.sh
+./demo.sh
+```
+
+### Python
+
+```bash
+python run_demo.py
+```
+
+## Step-by-Step Walkthrough
+
+### 1. Upload audit records
+
+Each record is uploaded with the `AUDIT-LOG-V1` provenance standard:
+
+```bash
+swarm-prov-upload upload --file audit_record_001.json --std "AUDIT-LOG-V1" --usePool
+swarm-prov-upload upload --file audit_record_002.json --std "AUDIT-LOG-V1" --usePool
+swarm-prov-upload upload --file audit_record_003.json --std "AUDIT-LOG-V1" --usePool
+```
+
+The `--std` flag tags the metadata envelope with the provenance standard, identifying these as audit log entries.
+
+### 2. Download and verify
+
+```bash
+swarm-prov-upload download <swarm_hash> --output-dir ./downloads
+```
+
+### 3. Verify integrity
+
+Compare SHA-256 hashes of the original and downloaded files:
+
+```bash
+shasum -a 256 audit_record_001.json
+shasum -a 256 downloads/*.data
+```
+
+If the hashes match, the record is intact.
+
+## Sample Records
+
+| File | Event Type | Description |
+|------|-----------|-------------|
+| `audit_record_001.json` | Transaction approval | Finance manager approves Q2 payment |
+| `audit_record_002.json` | Data access | Analyst queries EU customer dataset |
+| `audit_record_003.json` | Config change | Sysadmin modifies firewall rules |
+
+## Metadata Envelope
+
+When uploaded with `--std "AUDIT-LOG-V1"`, the metadata envelope includes:
+
+```json
+{
+  "data": "<base64-encoded audit record>",
+  "content_hash": "<sha256 of original file>",
+  "stamp_id": "<postage stamp used>",
+  "provenance_standard": "AUDIT-LOG-V1"
+}
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `demo.sh` | Shell demo — uploads 3 records, downloads and verifies one |
+| `run_demo.py` | Python demo — same workflow with argparse support |
+| `audit_record_001.json` | Sample: transaction approval event |
+| `audit_record_002.json` | Sample: data access event |
+| `audit_record_003.json` | Sample: configuration change event |

--- a/examples/02-audit-trail/audit_record_001.json
+++ b/examples/02-audit-trail/audit_record_001.json
@@ -1,0 +1,28 @@
+{
+  "event_type": "transaction_approval",
+  "event_id": "EVT-2025-001",
+  "timestamp": "2025-06-15T09:30:00Z",
+  "actor": {
+    "id": "USR-1042",
+    "role": "finance_manager",
+    "department": "treasury"
+  },
+  "action": {
+    "type": "approve",
+    "target": "TXN-88291",
+    "amount": 45000.00,
+    "currency": "USD",
+    "description": "Q2 infrastructure payment"
+  },
+  "context": {
+    "ip_address": "10.0.1.42",
+    "session_id": "sess-a1b2c3d4",
+    "approval_level": 2,
+    "required_levels": 2
+  },
+  "compliance": {
+    "policy": "FIN-POL-003",
+    "regulation": "SOX-404",
+    "audit_trail_required": true
+  }
+}

--- a/examples/02-audit-trail/audit_record_002.json
+++ b/examples/02-audit-trail/audit_record_002.json
@@ -1,0 +1,28 @@
+{
+  "event_type": "data_access",
+  "event_id": "EVT-2025-002",
+  "timestamp": "2025-06-15T10:15:00Z",
+  "actor": {
+    "id": "USR-2087",
+    "role": "data_analyst",
+    "department": "analytics"
+  },
+  "action": {
+    "type": "read",
+    "target": "DS-CUSTOMER-EU",
+    "records_accessed": 15420,
+    "description": "Customer segmentation analysis"
+  },
+  "context": {
+    "ip_address": "10.0.2.18",
+    "session_id": "sess-e5f6g7h8",
+    "query_id": "QRY-44102",
+    "execution_time_ms": 2340
+  },
+  "compliance": {
+    "policy": "DATA-POL-001",
+    "regulation": "GDPR-Art30",
+    "data_classification": "personal",
+    "purpose_limitation": "analytics"
+  }
+}

--- a/examples/02-audit-trail/audit_record_003.json
+++ b/examples/02-audit-trail/audit_record_003.json
@@ -1,0 +1,29 @@
+{
+  "event_type": "config_change",
+  "event_id": "EVT-2025-003",
+  "timestamp": "2025-06-15T14:45:00Z",
+  "actor": {
+    "id": "USR-0501",
+    "role": "sysadmin",
+    "department": "infrastructure"
+  },
+  "action": {
+    "type": "modify",
+    "target": "firewall-rule-set",
+    "change_description": "Added inbound rule for monitoring subnet",
+    "previous_value": "deny 10.0.5.0/24",
+    "new_value": "allow 10.0.5.0/24 port 9090"
+  },
+  "context": {
+    "ip_address": "10.0.0.5",
+    "session_id": "sess-i9j0k1l2",
+    "change_ticket": "CHG-7891",
+    "approved_by": "USR-0102"
+  },
+  "compliance": {
+    "policy": "SEC-POL-007",
+    "regulation": "ISO27001-A12",
+    "change_management_required": true,
+    "rollback_available": true
+  }
+}

--- a/examples/02-audit-trail/demo.sh
+++ b/examples/02-audit-trail/demo.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Audit Trail Demo
+#
+# Demonstrates immutable compliance audit records on Swarm:
+# 1. Upload multiple audit records with --std "AUDIT-LOG-V1"
+# 2. Download and verify one record
+# 3. Prove data integrity via SHA-256
+#
+# Usage: ./demo.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DOWNLOAD_DIR="$SCRIPT_DIR/downloads"
+
+echo "======================================"
+echo "  Swarm Provenance CLI - Audit Trail"
+echo "======================================"
+echo
+
+# --- Step 0: Check CLI is installed ---
+if ! command -v swarm-prov-upload &>/dev/null; then
+    echo "ERROR: swarm-prov-upload not found. Install with: pip install -e ."
+    exit 1
+fi
+
+echo "CLI version: $(swarm-prov-upload --version)"
+echo
+
+# --- Step 1: Check gateway health ---
+echo "--- Step 1: Check gateway health ---"
+swarm-prov-upload health
+echo
+
+# --- Step 2: Upload audit records ---
+echo "--- Step 2: Upload audit records with --std AUDIT-LOG-V1 ---"
+
+RECORDS=("audit_record_001.json" "audit_record_002.json" "audit_record_003.json")
+declare -a REFS=()
+
+for record in "${RECORDS[@]}"; do
+    FILE="$SCRIPT_DIR/$record"
+    echo "Uploading: $record"
+    echo "  SHA256: $(shasum -a 256 "$FILE" | cut -d' ' -f1)"
+
+    UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$FILE" --std "AUDIT-LOG-V1" --usePool 2>&1) || {
+        echo "  Pool not available, falling back to regular stamp purchase..."
+        UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$FILE" --std "AUDIT-LOG-V1" 2>&1)
+    }
+
+    SWARM_REF=$(echo "$UPLOAD_OUTPUT" | grep -A1 "Swarm Reference Hash:" | tail -1 | tr -d '[:space:]')
+
+    if [ -z "$SWARM_REF" ] || [ ${#SWARM_REF} -lt 64 ]; then
+        echo "ERROR: Could not extract Swarm reference for $record"
+        echo "Raw output: $UPLOAD_OUTPUT"
+        exit 1
+    fi
+
+    REFS+=("$SWARM_REF")
+    echo "  Reference: $SWARM_REF"
+    echo
+done
+
+echo "All ${#RECORDS[@]} audit records uploaded."
+echo
+
+# --- Step 3: Download and verify one record ---
+echo "--- Step 3: Download and verify first record ---"
+rm -rf "$DOWNLOAD_DIR"
+mkdir -p "$DOWNLOAD_DIR"
+
+VERIFY_REF="${REFS[0]}"
+echo "Downloading: $VERIFY_REF"
+swarm-prov-upload download "$VERIFY_REF" --output-dir "$DOWNLOAD_DIR"
+echo
+
+# --- Step 4: Verify integrity ---
+echo "--- Step 4: Compare SHA-256 hashes ---"
+ORIGINAL_HASH=$(shasum -a 256 "$SCRIPT_DIR/audit_record_001.json" | cut -d' ' -f1)
+DOWNLOADED_FILE=$(ls "$DOWNLOAD_DIR"/*.data 2>/dev/null | head -1)
+if [ -z "$DOWNLOADED_FILE" ]; then
+    DOWNLOADED_FILE=$(ls "$DOWNLOAD_DIR"/ | head -1)
+    DOWNLOADED_FILE="$DOWNLOAD_DIR/$DOWNLOADED_FILE"
+fi
+DOWNLOADED_HASH=$(shasum -a 256 "$DOWNLOADED_FILE" | cut -d' ' -f1)
+
+echo "Original:   $ORIGINAL_HASH"
+echo "Downloaded: $DOWNLOADED_HASH"
+echo
+
+if [ "$ORIGINAL_HASH" = "$DOWNLOADED_HASH" ]; then
+    echo "PASS: Audit record integrity verified - hashes match."
+else
+    echo "FAIL: Hash mismatch - audit record may have been tampered with!"
+    exit 1
+fi
+
+echo
+echo "--- Demo complete ---"
+echo "Uploaded ${#RECORDS[@]} audit records with AUDIT-LOG-V1 standard."
+echo "Swarm References:"
+for i in "${!RECORDS[@]}"; do
+    echo "  ${RECORDS[$i]}: ${REFS[$i]}"
+done
+echo "These immutable records can be retrieved from any Swarm gateway."

--- a/examples/02-audit-trail/run_demo.py
+++ b/examples/02-audit-trail/run_demo.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Audit Trail Demo - Python Version
+
+Demonstrates immutable compliance audit records on Swarm:
+1. Upload multiple audit records with --std "AUDIT-LOG-V1"
+2. Download and verify one record
+3. Prove data integrity via SHA-256
+
+Usage:
+    python run_demo.py
+    python run_demo.py --records audit_record_001.json audit_record_002.json
+"""
+
+import argparse
+import hashlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+
+DEFAULT_RECORDS = [
+    "audit_record_001.json",
+    "audit_record_002.json",
+    "audit_record_003.json",
+]
+
+
+def sha256_file(path: str) -> str:
+    """Compute SHA-256 hash of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def run_cli(*args) -> subprocess.CompletedProcess:
+    """Run a swarm-prov-upload CLI command."""
+    cmd = ["swarm-prov-upload"] + list(args)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result
+
+
+def extract_swarm_ref(output: str) -> str:
+    """Extract Swarm reference hash from CLI output."""
+    lines = output.splitlines()
+    for i, line in enumerate(lines):
+        if "Swarm Reference Hash:" in line and i + 1 < len(lines):
+            ref = lines[i + 1].strip()
+            if len(ref) >= 64:
+                return ref
+    return ""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Audit trail demo")
+    parser.add_argument(
+        "--records", "-r",
+        nargs="+",
+        default=DEFAULT_RECORDS,
+        help="Audit record files to upload (default: all 3 sample records)",
+    )
+    args = parser.parse_args()
+
+    print("=" * 50)
+    print("  Swarm Provenance CLI - Audit Trail (Python)")
+    print("=" * 50)
+
+    # --- Step 1: Check health ---
+    print("\n--- Step 1: Check gateway health ---")
+    result = run_cli("health")
+    if result.returncode != 0:
+        print(f"Gateway not available: {result.stderr or result.stdout}")
+        sys.exit(1)
+    print(result.stdout.strip())
+
+    # --- Step 2: Upload audit records ---
+    print("\n--- Step 2: Upload audit records with --std AUDIT-LOG-V1 ---")
+    refs = {}
+
+    for record_name in args.records:
+        record_path = str(SCRIPT_DIR / record_name)
+        if not os.path.exists(record_path):
+            print(f"ERROR: File not found: {record_path}")
+            sys.exit(1)
+
+        original_hash = sha256_file(record_path)
+        print(f"\nUploading: {record_name}")
+        print(f"  SHA256: {original_hash}")
+
+        result = run_cli("upload", "--file", record_path, "--std", "AUDIT-LOG-V1", "--usePool")
+        if result.returncode != 0:
+            print("  Pool not available, falling back to regular stamp purchase...")
+            result = run_cli("upload", "--file", record_path, "--std", "AUDIT-LOG-V1")
+            if result.returncode != 0:
+                print(f"  Upload failed: {result.stderr or result.stdout}")
+                sys.exit(1)
+
+        swarm_ref = extract_swarm_ref(result.stdout)
+        if not swarm_ref:
+            print(f"  Could not extract Swarm reference from output")
+            sys.exit(1)
+
+        refs[record_name] = swarm_ref
+        print(f"  Reference: {swarm_ref}")
+
+    print(f"\nAll {len(refs)} audit records uploaded.")
+
+    # --- Step 3: Download and verify first record ---
+    first_record = args.records[0]
+    first_ref = refs[first_record]
+
+    print(f"\n--- Step 3: Download and verify {first_record} ---")
+    download_dir = str(SCRIPT_DIR / "downloads")
+    os.makedirs(download_dir, exist_ok=True)
+    for f in os.listdir(download_dir):
+        os.remove(os.path.join(download_dir, f))
+
+    result = run_cli("download", first_ref, "--output-dir", download_dir)
+    if result.returncode != 0:
+        print(f"Download failed: {result.stderr or result.stdout}")
+        sys.exit(1)
+    print(result.stdout.strip())
+
+    # --- Step 4: Verify integrity ---
+    print("\n--- Step 4: Verify integrity ---")
+    downloaded_files = os.listdir(download_dir)
+    if not downloaded_files:
+        print("ERROR: No files in download directory")
+        sys.exit(1)
+
+    data_files = [f for f in downloaded_files if f.endswith(".data")]
+    if data_files:
+        downloaded_file = os.path.join(download_dir, data_files[0])
+    else:
+        downloaded_file = os.path.join(download_dir, downloaded_files[0])
+
+    original_hash = sha256_file(str(SCRIPT_DIR / first_record))
+    downloaded_hash = sha256_file(downloaded_file)
+
+    print(f"Original:   {original_hash}")
+    print(f"Downloaded: {downloaded_hash}")
+
+    if original_hash == downloaded_hash:
+        print("\nPASS: Audit record integrity verified - hashes match.")
+    else:
+        print("\nFAIL: Hash mismatch - audit record may have been tampered with!")
+        sys.exit(1)
+
+    # --- Summary ---
+    print("\n--- Summary ---")
+    print(f"Uploaded {len(refs)} audit records with AUDIT-LOG-V1 standard.")
+    print("Swarm References:")
+    for name, ref in refs.items():
+        print(f"  {name}: {ref}")
+    print("These immutable records can be retrieved from any Swarm gateway.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03-scientific-data/README.md
+++ b/examples/03-scientific-data/README.md
@@ -1,0 +1,95 @@
+# Example 03: Scientific Data
+
+Demonstrates research data archival on Swarm with extended retention.
+
+## What This Demonstrates
+
+- Uploading experiment metadata with `--std "PROV-O"` provenance standard
+- Using `--duration 720` for 30-day data retention
+- Archiving both metadata and raw data files
+- Downloading and verifying research data integrity
+
+## Use Case
+
+Research institutions need to archive experiment data with clear provenance tracking. The PROV-O standard (W3C provenance ontology) tags data with its scientific context, while extended duration ensures the data remains accessible for the retention period required by the research protocol.
+
+## Prerequisites
+
+1. Install the CLI: `pip install -e .`
+2. Gateway access (default, no setup needed)
+
+## Quick Start
+
+### Shell
+
+```bash
+chmod +x demo.sh
+./demo.sh
+```
+
+### Python
+
+```bash
+python run_demo.py
+```
+
+## Step-by-Step Walkthrough
+
+### 1. Upload experiment metadata
+
+The metadata JSON describes the experiment (PI, methodology, sensors) and is uploaded with PROV-O standard and 30-day retention:
+
+```bash
+swarm-prov-upload upload \
+    --file dataset_metadata.json \
+    --std "PROV-O" \
+    --duration 720 \
+    --usePool
+```
+
+The `--duration 720` flag requests a postage stamp valid for 720 hours (30 days). If this duration is not available (e.g., due to gateway limitations or cost), the demo falls back to the default duration.
+
+### 2. Upload experiment results
+
+The CSV file with sensor readings is uploaded separately:
+
+```bash
+swarm-prov-upload upload \
+    --file experiment_results.csv \
+    --std "PROV-O" \
+    --usePool
+```
+
+### 3. Download and verify
+
+```bash
+swarm-prov-upload download <csv_reference> --output-dir ./downloads
+shasum -a 256 experiment_results.csv downloads/*.data
+```
+
+## Sample Data
+
+### dataset_metadata.json
+
+Experiment metadata following the PROV-O model:
+- Experiment ID, principal investigator, institution
+- Methodology: sensor type, sampling interval, calibration
+- Data file references and column descriptions
+
+### experiment_results.csv
+
+8 sensor readings with columns:
+- `timestamp` — ISO 8601 UTC
+- `station_id` — Monitoring station identifier
+- `temperature_c` — Temperature in Celsius
+- `humidity_pct` — Relative humidity percentage
+- `status` — Reading status (normal/warning)
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `demo.sh` | Shell demo — uploads metadata and CSV, downloads and verifies |
+| `run_demo.py` | Python demo — same workflow with argparse support |
+| `dataset_metadata.json` | Experiment metadata (PROV-O format) |
+| `experiment_results.csv` | Sensor readings (8 rows) |

--- a/examples/03-scientific-data/dataset_metadata.json
+++ b/examples/03-scientific-data/dataset_metadata.json
@@ -1,0 +1,28 @@
+{
+  "title": "Indoor Environmental Monitoring - Building A, Floor 3",
+  "description": "Temperature and humidity sensor readings from environmental monitoring stations",
+  "prov_standard": "PROV-O",
+  "experiment": {
+    "id": "EXP-ENV-2025-042",
+    "principal_investigator": "Dr. M. Chen",
+    "institution": "Climate Research Institute",
+    "start_date": "2025-06-01",
+    "end_date": "2025-06-15"
+  },
+  "methodology": {
+    "sensor_type": "DHT22",
+    "sampling_interval_seconds": 300,
+    "calibration_date": "2025-05-28",
+    "stations": ["STA-3A", "STA-3B", "STA-3C", "STA-3D"]
+  },
+  "data_files": [
+    {
+      "filename": "experiment_results.csv",
+      "format": "CSV",
+      "records": 8,
+      "columns": ["timestamp", "station_id", "temperature_c", "humidity_pct", "status"]
+    }
+  ],
+  "license": "CC-BY-4.0",
+  "keywords": ["environmental monitoring", "temperature", "humidity", "indoor air quality"]
+}

--- a/examples/03-scientific-data/demo.sh
+++ b/examples/03-scientific-data/demo.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Scientific Data Demo
+#
+# Demonstrates research data archival on Swarm:
+# 1. Upload experiment metadata with --std "PROV-O" --duration 720 (30 days)
+# 2. Upload experiment results CSV
+# 3. Download and verify the CSV data
+#
+# Usage: ./demo.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+METADATA_FILE="$SCRIPT_DIR/dataset_metadata.json"
+RESULTS_FILE="$SCRIPT_DIR/experiment_results.csv"
+DOWNLOAD_DIR="$SCRIPT_DIR/downloads"
+
+echo "========================================="
+echo "  Swarm Provenance CLI - Scientific Data"
+echo "========================================="
+echo
+
+# --- Step 0: Check CLI is installed ---
+if ! command -v swarm-prov-upload &>/dev/null; then
+    echo "ERROR: swarm-prov-upload not found. Install with: pip install -e ."
+    exit 1
+fi
+
+echo "CLI version: $(swarm-prov-upload --version)"
+echo
+
+# --- Step 1: Check gateway health ---
+echo "--- Step 1: Check gateway health ---"
+swarm-prov-upload health
+echo
+
+# --- Step 2: Upload metadata with PROV-O standard and 30-day retention ---
+echo "--- Step 2: Upload experiment metadata (PROV-O, 30-day retention) ---"
+echo "File: $METADATA_FILE"
+echo "SHA256: $(shasum -a 256 "$METADATA_FILE" | cut -d' ' -f1)"
+echo
+
+echo "Uploading with --std PROV-O --duration 720 (trying pool first)..."
+UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$METADATA_FILE" --std "PROV-O" --duration 720 --usePool 2>&1) || {
+    echo "Pool not available, trying without pool..."
+    UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$METADATA_FILE" --std "PROV-O" --duration 720 2>&1) || {
+        echo "Long duration not available, falling back to default duration..."
+        UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$METADATA_FILE" --std "PROV-O" --usePool 2>&1) || {
+            UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$METADATA_FILE" --std "PROV-O" 2>&1)
+        }
+    }
+}
+echo "$UPLOAD_OUTPUT"
+
+META_REF=$(echo "$UPLOAD_OUTPUT" | grep -A1 "Swarm Reference Hash:" | tail -1 | tr -d '[:space:]')
+
+if [ -z "$META_REF" ] || [ ${#META_REF} -lt 64 ]; then
+    echo "ERROR: Could not extract Swarm reference for metadata."
+    exit 1
+fi
+
+echo
+echo "Metadata Reference: $META_REF"
+echo
+
+# --- Step 3: Upload experiment results CSV ---
+echo "--- Step 3: Upload experiment results CSV ---"
+echo "File: $RESULTS_FILE"
+echo "SHA256: $(shasum -a 256 "$RESULTS_FILE" | cut -d' ' -f1)"
+echo
+
+echo "Uploading (trying pool first)..."
+UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$RESULTS_FILE" --std "PROV-O" --usePool 2>&1) || {
+    echo "Pool not available, falling back to regular stamp purchase..."
+    UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$RESULTS_FILE" --std "PROV-O" 2>&1)
+}
+echo "$UPLOAD_OUTPUT"
+
+CSV_REF=$(echo "$UPLOAD_OUTPUT" | grep -A1 "Swarm Reference Hash:" | tail -1 | tr -d '[:space:]')
+
+if [ -z "$CSV_REF" ] || [ ${#CSV_REF} -lt 64 ]; then
+    echo "ERROR: Could not extract Swarm reference for results CSV."
+    exit 1
+fi
+
+echo
+echo "Results Reference: $CSV_REF"
+echo
+
+# --- Step 4: Download and verify the CSV ---
+echo "--- Step 4: Download and verify results CSV ---"
+rm -rf "$DOWNLOAD_DIR"
+mkdir -p "$DOWNLOAD_DIR"
+
+swarm-prov-upload download "$CSV_REF" --output-dir "$DOWNLOAD_DIR"
+echo
+
+echo "--- Step 5: Compare SHA-256 hashes ---"
+ORIGINAL_HASH=$(shasum -a 256 "$RESULTS_FILE" | cut -d' ' -f1)
+DOWNLOADED_FILE=$(ls "$DOWNLOAD_DIR"/*.data 2>/dev/null | head -1)
+if [ -z "$DOWNLOADED_FILE" ]; then
+    DOWNLOADED_FILE=$(ls "$DOWNLOAD_DIR"/ | head -1)
+    DOWNLOADED_FILE="$DOWNLOAD_DIR/$DOWNLOADED_FILE"
+fi
+DOWNLOADED_HASH=$(shasum -a 256 "$DOWNLOADED_FILE" | cut -d' ' -f1)
+
+echo "Original:   $ORIGINAL_HASH"
+echo "Downloaded: $DOWNLOADED_HASH"
+echo
+
+if [ "$ORIGINAL_HASH" = "$DOWNLOADED_HASH" ]; then
+    echo "PASS: Experiment data integrity verified - hashes match."
+else
+    echo "FAIL: Hash mismatch - data may have been corrupted!"
+    exit 1
+fi
+
+echo
+echo "--- Demo complete ---"
+echo "Metadata Reference: $META_REF"
+echo "Results Reference:  $CSV_REF"
+echo "Both datasets are archived on Swarm with PROV-O provenance standard."

--- a/examples/03-scientific-data/experiment_results.csv
+++ b/examples/03-scientific-data/experiment_results.csv
@@ -1,0 +1,9 @@
+timestamp,station_id,temperature_c,humidity_pct,status
+2025-06-01T08:00:00Z,STA-3A,22.4,45.2,normal
+2025-06-01T08:05:00Z,STA-3B,22.1,46.8,normal
+2025-06-01T08:10:00Z,STA-3C,23.0,44.1,normal
+2025-06-01T08:15:00Z,STA-3D,21.8,47.5,normal
+2025-06-01T08:20:00Z,STA-3A,22.6,45.0,normal
+2025-06-01T08:25:00Z,STA-3B,22.3,46.5,normal
+2025-06-01T08:30:00Z,STA-3C,24.1,42.3,warning
+2025-06-01T08:35:00Z,STA-3D,21.9,47.2,normal

--- a/examples/03-scientific-data/run_demo.py
+++ b/examples/03-scientific-data/run_demo.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Scientific Data Demo - Python Version
+
+Demonstrates research data archival on Swarm:
+1. Upload experiment metadata with --std "PROV-O" --duration 720 (30 days)
+2. Upload experiment results CSV
+3. Download and verify the CSV data
+
+Usage:
+    python run_demo.py
+    python run_demo.py --metadata dataset_metadata.json --results experiment_results.csv
+"""
+
+import argparse
+import hashlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+
+
+def sha256_file(path: str) -> str:
+    """Compute SHA-256 hash of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def run_cli(*args) -> subprocess.CompletedProcess:
+    """Run a swarm-prov-upload CLI command."""
+    cmd = ["swarm-prov-upload"] + list(args)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result
+
+
+def extract_swarm_ref(output: str) -> str:
+    """Extract Swarm reference hash from CLI output."""
+    lines = output.splitlines()
+    for i, line in enumerate(lines):
+        if "Swarm Reference Hash:" in line and i + 1 < len(lines):
+            ref = lines[i + 1].strip()
+            if len(ref) >= 64:
+                return ref
+    return ""
+
+
+def upload_file(file_path: str, std: str, duration: int = None) -> str:
+    """Upload a file and return its Swarm reference.
+
+    Tries pool first, then regular stamp purchase.
+    If duration is specified, tries with duration first, falls back to default.
+    """
+    extra_args = ["--std", std]
+    if duration:
+        extra_args += ["--duration", str(duration)]
+
+    # Try pool first
+    result = run_cli("upload", "--file", file_path, *extra_args, "--usePool")
+    if result.returncode == 0:
+        ref = extract_swarm_ref(result.stdout)
+        if ref:
+            print(result.stdout.strip())
+            return ref
+
+    # Try without pool
+    print("  Pool not available, trying without pool...")
+    result = run_cli("upload", "--file", file_path, *extra_args)
+    if result.returncode == 0:
+        ref = extract_swarm_ref(result.stdout)
+        if ref:
+            print(result.stdout.strip())
+            return ref
+
+    # If duration was set, fall back to default duration
+    if duration:
+        print(f"  Duration {duration}h not available, falling back to default...")
+        return upload_file(file_path, std)
+
+    print(f"  Upload failed: {result.stderr or result.stdout}")
+    sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scientific data archival demo")
+    parser.add_argument(
+        "--metadata", "-m",
+        default=str(SCRIPT_DIR / "dataset_metadata.json"),
+        help="Metadata JSON file (default: dataset_metadata.json)",
+    )
+    parser.add_argument(
+        "--results", "-r",
+        default=str(SCRIPT_DIR / "experiment_results.csv"),
+        help="Results CSV file (default: experiment_results.csv)",
+    )
+    args = parser.parse_args()
+
+    for f in [args.metadata, args.results]:
+        if not os.path.exists(f):
+            print(f"ERROR: File not found: {f}")
+            sys.exit(1)
+
+    print("=" * 55)
+    print("  Swarm Provenance CLI - Scientific Data (Python)")
+    print("=" * 55)
+
+    # --- Step 1: Check health ---
+    print("\n--- Step 1: Check gateway health ---")
+    result = run_cli("health")
+    if result.returncode != 0:
+        print(f"Gateway not available: {result.stderr or result.stdout}")
+        sys.exit(1)
+    print(result.stdout.strip())
+
+    # --- Step 2: Upload metadata with PROV-O and 30-day retention ---
+    print("\n--- Step 2: Upload metadata (PROV-O, 30-day retention) ---")
+    meta_hash = sha256_file(args.metadata)
+    print(f"File:   {args.metadata}")
+    print(f"SHA256: {meta_hash}")
+    print("\nUploading with --std PROV-O --duration 720...")
+    meta_ref = upload_file(args.metadata, "PROV-O", duration=720)
+    print(f"\nMetadata Reference: {meta_ref}")
+
+    # --- Step 3: Upload results CSV ---
+    print("\n--- Step 3: Upload experiment results CSV ---")
+    csv_hash = sha256_file(args.results)
+    print(f"File:   {args.results}")
+    print(f"SHA256: {csv_hash}")
+    print("\nUploading with --std PROV-O...")
+    csv_ref = upload_file(args.results, "PROV-O")
+    print(f"\nResults Reference: {csv_ref}")
+
+    # --- Step 4: Download and verify CSV ---
+    print("\n--- Step 4: Download and verify results CSV ---")
+    download_dir = str(SCRIPT_DIR / "downloads")
+    os.makedirs(download_dir, exist_ok=True)
+    for f in os.listdir(download_dir):
+        os.remove(os.path.join(download_dir, f))
+
+    result = run_cli("download", csv_ref, "--output-dir", download_dir)
+    if result.returncode != 0:
+        print(f"Download failed: {result.stderr or result.stdout}")
+        sys.exit(1)
+    print(result.stdout.strip())
+
+    # --- Step 5: Verify integrity ---
+    print("\n--- Step 5: Verify integrity ---")
+    downloaded_files = os.listdir(download_dir)
+    if not downloaded_files:
+        print("ERROR: No files in download directory")
+        sys.exit(1)
+
+    data_files = [f for f in downloaded_files if f.endswith(".data")]
+    if data_files:
+        downloaded_file = os.path.join(download_dir, data_files[0])
+    else:
+        downloaded_file = os.path.join(download_dir, downloaded_files[0])
+
+    original_hash = sha256_file(args.results)
+    downloaded_hash = sha256_file(downloaded_file)
+
+    print(f"Original:   {original_hash}")
+    print(f"Downloaded: {downloaded_hash}")
+
+    if original_hash == downloaded_hash:
+        print("\nPASS: Experiment data integrity verified - hashes match.")
+    else:
+        print("\nFAIL: Hash mismatch - data may have been corrupted!")
+        sys.exit(1)
+
+    # --- Summary ---
+    print("\n--- Summary ---")
+    print(f"Metadata Reference: {meta_ref}")
+    print(f"Results Reference:  {csv_ref}")
+    print("Both datasets archived on Swarm with PROV-O provenance standard.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05-encrypted-data/README.md
+++ b/examples/05-encrypted-data/README.md
@@ -1,0 +1,110 @@
+# Example 05: Encrypted Data
+
+Demonstrates pre-encryption workflow for sensitive data on Swarm.
+
+## What This Demonstrates
+
+- Encrypting data locally before upload
+- Using `--enc "AES-256-GCM"` to tag the metadata envelope with encryption info
+- Downloading and verifying the encrypted payload is intact
+- Decrypting and verifying the content matches the original
+
+## Use Case
+
+When storing sensitive data (medical records, financial data, PII) on a decentralized network, the data should be encrypted before upload. The `--enc` flag doesn't perform encryption — it records the encryption method in the metadata envelope so consumers know how to decrypt.
+
+**Workflow:**
+1. Encrypt data locally using your preferred encryption library
+2. Upload the encrypted payload with `--enc` tag to record the method
+3. Store the encryption key separately (key management system, hardware wallet, etc.)
+4. To retrieve: download the payload, check the encryption tag, decrypt with the key
+
+## Prerequisites
+
+1. Install the CLI: `pip install -e .`
+2. Gateway access (default, no setup needed)
+3. For shell demo: `openssl` (pre-installed on macOS/Linux)
+
+## Quick Start
+
+### Shell (uses openssl)
+
+```bash
+chmod +x demo.sh
+./demo.sh
+```
+
+### Python (uses XOR cipher — demo only)
+
+```bash
+python run_demo.py
+```
+
+## Step-by-Step Walkthrough
+
+### 1. Encrypt the data locally
+
+**Shell (openssl):**
+```bash
+openssl rand -out key.bin 32
+openssl enc -aes-256-cbc -salt -in sensitive_data.txt -out sensitive_data.enc -pass file:key.bin -pbkdf2
+```
+
+**Python (demo XOR cipher):**
+```python
+key = os.urandom(32)
+encrypted = xor_encrypt(original_data, key)
+```
+
+### 2. Upload encrypted payload with encryption tag
+
+```bash
+swarm-prov-upload upload --file sensitive_data.enc --enc "AES-256-GCM" --usePool
+```
+
+The `--enc` flag adds an `encryption` field to the metadata envelope, recording that this data is encrypted with AES-256-GCM.
+
+### 3. Download and verify the encrypted payload
+
+```bash
+swarm-prov-upload download <swarm_hash> --output-dir ./downloads
+shasum -a 256 sensitive_data.enc downloads/*.data
+```
+
+### 4. Decrypt and verify
+
+```bash
+openssl enc -aes-256-cbc -d -in downloads/*.data -out decrypted.txt -pass file:key.bin -pbkdf2
+shasum -a 256 sensitive_data.txt decrypted.txt
+```
+
+## Metadata Envelope
+
+When uploaded with `--enc "AES-256-GCM"`, the envelope includes:
+
+```json
+{
+  "data": "<base64-encoded encrypted payload>",
+  "content_hash": "<sha256 of encrypted payload>",
+  "stamp_id": "<postage stamp used>",
+  "encryption": "AES-256-GCM"
+}
+```
+
+The `encryption` field tells consumers what algorithm was used, but the key is not stored on Swarm.
+
+## Security Notes
+
+- The demo scripts use simplified encryption (openssl CBC / XOR) for illustration only
+- In production, use a proper encryption library with authenticated encryption (e.g., AES-256-GCM via `cryptography` library)
+- Never store encryption keys alongside encrypted data
+- Use a key management system (KMS) for production key storage
+- The `--enc` tag is metadata only — it does not perform encryption
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `demo.sh` | Shell demo — encrypts with openssl, uploads, downloads, decrypts |
+| `run_demo.py` | Python demo — XOR cipher (demo only), same workflow |
+| `sensitive_data.txt` | Sample PII data (fictional patient record) |

--- a/examples/05-encrypted-data/demo.sh
+++ b/examples/05-encrypted-data/demo.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Encrypted Data Demo
+#
+# Demonstrates pre-encryption workflow with Swarm:
+# 1. Encrypt data locally with openssl
+# 2. Upload encrypted payload with --enc "AES-256-GCM" tag
+# 3. Download the encrypted payload
+# 4. Verify the encrypted payload is intact
+# 5. Decrypt and verify it matches the original
+#
+# Usage: ./demo.sh
+#
+# NOTE: This uses openssl for demonstration purposes.
+# In production, use a proper encryption library with key management.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SENSITIVE_FILE="$SCRIPT_DIR/sensitive_data.txt"
+DOWNLOAD_DIR="$SCRIPT_DIR/downloads"
+ENCRYPTED_FILE="$SCRIPT_DIR/sensitive_data.enc"
+DECRYPTED_FILE="$SCRIPT_DIR/sensitive_data.dec"
+KEY_FILE="$SCRIPT_DIR/demo_key.bin"
+
+echo "========================================="
+echo "  Swarm Provenance CLI - Encrypted Data"
+echo "========================================="
+echo
+echo "WARNING: This demo uses openssl for illustration only."
+echo "         Use a proper encryption library in production."
+echo
+
+# --- Step 0: Check CLI and openssl ---
+if ! command -v swarm-prov-upload &>/dev/null; then
+    echo "ERROR: swarm-prov-upload not found. Install with: pip install -e ."
+    exit 1
+fi
+
+if ! command -v openssl &>/dev/null; then
+    echo "ERROR: openssl not found."
+    exit 1
+fi
+
+echo "CLI version: $(swarm-prov-upload --version)"
+echo
+
+# --- Step 1: Check gateway health ---
+echo "--- Step 1: Check gateway health ---"
+swarm-prov-upload health
+echo
+
+# --- Step 2: Encrypt the data ---
+echo "--- Step 2: Encrypt sensitive data ---"
+echo "Original file: $SENSITIVE_FILE"
+ORIGINAL_HASH=$(shasum -a 256 "$SENSITIVE_FILE" | cut -d' ' -f1)
+echo "Original SHA256: $ORIGINAL_HASH"
+echo
+
+# Generate a random 256-bit key and IV
+openssl rand -out "$KEY_FILE" 32
+# Encrypt with AES-256-CBC (GCM not available in all openssl versions via enc)
+openssl enc -aes-256-cbc -salt -in "$SENSITIVE_FILE" -out "$ENCRYPTED_FILE" -pass file:"$KEY_FILE" -pbkdf2
+
+ENCRYPTED_HASH=$(shasum -a 256 "$ENCRYPTED_FILE" | cut -d' ' -f1)
+echo "Encrypted file: $ENCRYPTED_FILE"
+echo "Encrypted SHA256: $ENCRYPTED_HASH"
+echo "Key saved to: $KEY_FILE"
+echo
+
+# --- Step 3: Upload encrypted data with --enc tag ---
+echo "--- Step 3: Upload encrypted data with --enc AES-256-GCM ---"
+echo "Uploading (trying pool first)..."
+UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$ENCRYPTED_FILE" --enc "AES-256-GCM" --usePool 2>&1) || {
+    echo "Pool not available, falling back to regular stamp purchase..."
+    UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$ENCRYPTED_FILE" --enc "AES-256-GCM" 2>&1)
+}
+echo "$UPLOAD_OUTPUT"
+
+SWARM_REF=$(echo "$UPLOAD_OUTPUT" | grep -A1 "Swarm Reference Hash:" | tail -1 | tr -d '[:space:]')
+
+if [ -z "$SWARM_REF" ] || [ ${#SWARM_REF} -lt 64 ]; then
+    echo "ERROR: Could not extract Swarm reference."
+    exit 1
+fi
+
+echo
+echo "Swarm Reference: $SWARM_REF"
+echo
+
+# --- Step 4: Download the encrypted payload ---
+echo "--- Step 4: Download encrypted payload ---"
+rm -rf "$DOWNLOAD_DIR"
+mkdir -p "$DOWNLOAD_DIR"
+
+swarm-prov-upload download "$SWARM_REF" --output-dir "$DOWNLOAD_DIR"
+echo
+
+# --- Step 5: Verify encrypted payload is intact ---
+echo "--- Step 5: Verify encrypted payload integrity ---"
+DOWNLOADED_FILE=$(ls "$DOWNLOAD_DIR"/*.data 2>/dev/null | head -1)
+if [ -z "$DOWNLOADED_FILE" ]; then
+    DOWNLOADED_FILE=$(ls "$DOWNLOAD_DIR"/ | head -1)
+    DOWNLOADED_FILE="$DOWNLOAD_DIR/$DOWNLOADED_FILE"
+fi
+DOWNLOADED_HASH=$(shasum -a 256 "$DOWNLOADED_FILE" | cut -d' ' -f1)
+
+echo "Encrypted original: $ENCRYPTED_HASH"
+echo "Downloaded:         $DOWNLOADED_HASH"
+echo
+
+if [ "$ENCRYPTED_HASH" = "$DOWNLOADED_HASH" ]; then
+    echo "PASS: Encrypted payload integrity verified."
+else
+    echo "FAIL: Encrypted payload hash mismatch!"
+    rm -f "$ENCRYPTED_FILE" "$KEY_FILE" "$DECRYPTED_FILE"
+    exit 1
+fi
+
+# --- Step 6: Decrypt and verify ---
+echo
+echo "--- Step 6: Decrypt and verify original content ---"
+openssl enc -aes-256-cbc -d -in "$DOWNLOADED_FILE" -out "$DECRYPTED_FILE" -pass file:"$KEY_FILE" -pbkdf2
+DECRYPTED_HASH=$(shasum -a 256 "$DECRYPTED_FILE" | cut -d' ' -f1)
+
+echo "Original:  $ORIGINAL_HASH"
+echo "Decrypted: $DECRYPTED_HASH"
+echo
+
+if [ "$ORIGINAL_HASH" = "$DECRYPTED_HASH" ]; then
+    echo "PASS: Decrypted content matches original - full round-trip verified."
+else
+    echo "FAIL: Decrypted content does not match original!"
+    rm -f "$ENCRYPTED_FILE" "$KEY_FILE" "$DECRYPTED_FILE"
+    exit 1
+fi
+
+# Clean up temporary files
+rm -f "$ENCRYPTED_FILE" "$KEY_FILE" "$DECRYPTED_FILE"
+
+echo
+echo "--- Demo complete ---"
+echo "Swarm Reference: $SWARM_REF"
+echo "The data was encrypted locally, uploaded to Swarm with AES-256-GCM tag,"
+echo "downloaded, and decrypted back to the original content."

--- a/examples/05-encrypted-data/run_demo.py
+++ b/examples/05-encrypted-data/run_demo.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Encrypted Data Demo - Python Version
+
+Demonstrates pre-encryption workflow with Swarm:
+1. Encrypt data locally (XOR cipher for demo purposes)
+2. Upload encrypted payload with --enc "AES-256-GCM" tag
+3. Download the encrypted payload
+4. Verify the encrypted payload is intact
+5. Decrypt and verify it matches the original
+
+Usage:
+    python run_demo.py
+    python run_demo.py --file /path/to/sensitive.txt
+
+WARNING: This demo uses XOR cipher for illustration only.
+         NOT PRODUCTION-SAFE — use a real encryption library (e.g., cryptography)
+         with proper key management for actual sensitive data.
+"""
+
+import argparse
+import hashlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+
+
+def sha256_file(path: str) -> str:
+    """Compute SHA-256 hash of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def sha256_bytes(data: bytes) -> str:
+    """Compute SHA-256 hash of bytes."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def run_cli(*args) -> subprocess.CompletedProcess:
+    """Run a swarm-prov-upload CLI command."""
+    cmd = ["swarm-prov-upload"] + list(args)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result
+
+
+def extract_swarm_ref(output: str) -> str:
+    """Extract Swarm reference hash from CLI output."""
+    lines = output.splitlines()
+    for i, line in enumerate(lines):
+        if "Swarm Reference Hash:" in line and i + 1 < len(lines):
+            ref = lines[i + 1].strip()
+            if len(ref) >= 64:
+                return ref
+    return ""
+
+
+def xor_encrypt(data: bytes, key: bytes) -> bytes:
+    """XOR cipher — symmetric, same function encrypts and decrypts.
+
+    WARNING: NOT PRODUCTION-SAFE. This is a demo cipher only.
+    Use a real encryption library (e.g., cryptography, PyCryptodome) in production.
+    """
+    key_len = len(key)
+    return bytes(b ^ key[i % key_len] for i, b in enumerate(data))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Encrypted data upload demo")
+    parser.add_argument(
+        "--file", "-f",
+        default=str(SCRIPT_DIR / "sensitive_data.txt"),
+        help="File to encrypt and upload (default: sensitive_data.txt)",
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(args.file):
+        print(f"ERROR: File not found: {args.file}")
+        sys.exit(1)
+
+    print("=" * 55)
+    print("  Swarm Provenance CLI - Encrypted Data (Python)")
+    print("=" * 55)
+    print()
+    print("WARNING: This demo uses XOR cipher for illustration only.")
+    print("         Use a real encryption library in production.")
+
+    # --- Step 1: Check health ---
+    print("\n--- Step 1: Check gateway health ---")
+    result = run_cli("health")
+    if result.returncode != 0:
+        print(f"Gateway not available: {result.stderr or result.stdout}")
+        sys.exit(1)
+    print(result.stdout.strip())
+
+    # --- Step 2: Encrypt the data ---
+    print("\n--- Step 2: Encrypt sensitive data ---")
+    with open(args.file, "rb") as f:
+        original_data = f.read()
+
+    original_hash = sha256_bytes(original_data)
+    print(f"Original file:   {args.file}")
+    print(f"Original SHA256: {original_hash}")
+
+    # Generate random key and encrypt
+    key = os.urandom(32)
+    encrypted_data = xor_encrypt(original_data, key)
+    encrypted_hash = sha256_bytes(encrypted_data)
+
+    # Write encrypted file
+    encrypted_path = str(SCRIPT_DIR / "sensitive_data.enc")
+    with open(encrypted_path, "wb") as f:
+        f.write(encrypted_data)
+
+    print(f"Encrypted SHA256: {encrypted_hash}")
+    print(f"Key length: {len(key)} bytes (kept in memory)")
+
+    # --- Step 3: Upload encrypted data ---
+    print("\n--- Step 3: Upload encrypted data with --enc AES-256-GCM ---")
+    print("Uploading (trying pool first)...")
+    result = run_cli("upload", "--file", encrypted_path, "--enc", "AES-256-GCM", "--usePool")
+    if result.returncode != 0:
+        print("Pool not available, falling back to regular stamp purchase...")
+        result = run_cli("upload", "--file", encrypted_path, "--enc", "AES-256-GCM")
+        if result.returncode != 0:
+            print(f"Upload failed: {result.stderr or result.stdout}")
+            os.remove(encrypted_path)
+            sys.exit(1)
+
+    print(result.stdout.strip())
+
+    swarm_ref = extract_swarm_ref(result.stdout)
+    if not swarm_ref:
+        print("Could not extract Swarm reference from output")
+        os.remove(encrypted_path)
+        sys.exit(1)
+
+    print(f"\nSwarm Reference: {swarm_ref}")
+
+    # --- Step 4: Download encrypted payload ---
+    print("\n--- Step 4: Download encrypted payload ---")
+    download_dir = str(SCRIPT_DIR / "downloads")
+    os.makedirs(download_dir, exist_ok=True)
+    for f in os.listdir(download_dir):
+        os.remove(os.path.join(download_dir, f))
+
+    result = run_cli("download", swarm_ref, "--output-dir", download_dir)
+    if result.returncode != 0:
+        print(f"Download failed: {result.stderr or result.stdout}")
+        os.remove(encrypted_path)
+        sys.exit(1)
+    print(result.stdout.strip())
+
+    # --- Step 5: Verify encrypted payload integrity ---
+    print("\n--- Step 5: Verify encrypted payload integrity ---")
+    downloaded_files = os.listdir(download_dir)
+    if not downloaded_files:
+        print("ERROR: No files in download directory")
+        os.remove(encrypted_path)
+        sys.exit(1)
+
+    data_files = [f for f in downloaded_files if f.endswith(".data")]
+    if data_files:
+        downloaded_file = os.path.join(download_dir, data_files[0])
+    else:
+        downloaded_file = os.path.join(download_dir, downloaded_files[0])
+
+    downloaded_hash = sha256_file(downloaded_file)
+    print(f"Encrypted original: {encrypted_hash}")
+    print(f"Downloaded:         {downloaded_hash}")
+
+    if encrypted_hash != downloaded_hash:
+        print("\nFAIL: Encrypted payload hash mismatch!")
+        os.remove(encrypted_path)
+        sys.exit(1)
+    print("\nPASS: Encrypted payload integrity verified.")
+
+    # --- Step 6: Decrypt and verify ---
+    print("\n--- Step 6: Decrypt and verify original content ---")
+    with open(downloaded_file, "rb") as f:
+        downloaded_encrypted = f.read()
+
+    decrypted_data = xor_encrypt(downloaded_encrypted, key)
+    decrypted_hash = sha256_bytes(decrypted_data)
+
+    print(f"Original:  {original_hash}")
+    print(f"Decrypted: {decrypted_hash}")
+
+    if original_hash == decrypted_hash:
+        print("\nPASS: Decrypted content matches original - full round-trip verified.")
+    else:
+        print("\nFAIL: Decrypted content does not match original!")
+        os.remove(encrypted_path)
+        sys.exit(1)
+
+    # Clean up
+    os.remove(encrypted_path)
+
+    # --- Summary ---
+    print("\n--- Summary ---")
+    print(f"Swarm Reference: {swarm_ref}")
+    print("Data was encrypted locally, uploaded with AES-256-GCM metadata tag,")
+    print("downloaded, and decrypted back to the original content.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05-encrypted-data/sensitive_data.txt
+++ b/examples/05-encrypted-data/sensitive_data.txt
@@ -1,0 +1,21 @@
+Patient Record - CONFIDENTIAL
+==============================
+
+Patient ID: PT-2025-08421
+Name: Jane Doe
+DOB: 1985-03-15
+SSN: ***-**-7890
+
+Diagnosis: Hypertension Stage 1
+Prescribed: Lisinopril 10mg daily
+Last Visit: 2025-06-10
+Next Appointment: 2025-07-10
+
+Lab Results (2025-06-10):
+  Blood Pressure: 142/91 mmHg
+  Heart Rate: 78 bpm
+  Cholesterol: 215 mg/dL
+  Blood Glucose: 98 mg/dL
+
+Notes: Patient reports improved adherence to medication.
+Recommend follow-up in 30 days with repeat labs.

--- a/examples/06-market-memory/README.md
+++ b/examples/06-market-memory/README.md
@@ -1,0 +1,129 @@
+# Example 06: Market Memory
+
+Demonstrates market prediction memory units with canonical content hashing on Swarm.
+
+## What This Demonstrates
+
+- Canonical JSON hashing for deterministic content fingerprints
+- Uploading predictions with `--std "MARKET-MEMORY-V1"`
+- Linking observations back to predictions via Swarm references
+- Verifying content integrity through canonical hash recomputation
+
+## Use Case
+
+Trading agents produce predictions and later record observations (outcomes). Each memory unit contains a canonical content hash computed from its fields, ensuring any tampering is detectable. Observations link to their predictions via Swarm references, creating an auditable prediction→outcome chain.
+
+**Canonical hashing** ensures the same data always produces the same hash regardless of JSON key ordering:
+
+```python
+json.dumps(data, sort_keys=True, separators=(',', ':'))  →  SHA-256
+```
+
+The `content_hash` field is excluded from the hash computation to avoid circular dependency.
+
+## Prerequisites
+
+1. Install the CLI: `pip install -e .`
+2. Gateway access (default, no setup needed)
+
+## Quick Start
+
+### Shell
+
+```bash
+chmod +x demo.sh
+./demo.sh
+```
+
+### Python
+
+```bash
+python run_demo.py
+```
+
+## Step-by-Step Walkthrough
+
+### 1. Verify canonical hash
+
+Before uploading, verify the prediction's content hash:
+
+```bash
+python create_memory_unit.py verify prediction_001.json
+```
+
+### 2. Upload prediction
+
+```bash
+swarm-prov-upload upload --file prediction_001.json --std "MARKET-MEMORY-V1" --usePool
+```
+
+### 3. Upload observation with prediction reference
+
+The observation's `prediction_ref` field is updated with the actual Swarm hash of the uploaded prediction, then its canonical hash is recomputed:
+
+```bash
+# The demo scripts handle this automatically
+swarm-prov-upload upload --file observation.json --std "MARKET-MEMORY-V1" --usePool
+```
+
+### 4. Download and verify
+
+```bash
+swarm-prov-upload download <prediction_ref> --output-dir ./downloads
+python create_memory_unit.py verify downloads/*.data
+```
+
+## Memory Unit Helper
+
+`create_memory_unit.py` generates and verifies memory units:
+
+```bash
+# Create a prediction
+python create_memory_unit.py prediction --agent agent-alpha --market BTC/USD --direction up
+
+# Create an observation linking to a prediction
+python create_memory_unit.py observation --agent agent-alpha --market BTC/USD \
+    --prediction-ref <swarm_hash>
+
+# Verify a unit's canonical hash
+python create_memory_unit.py verify prediction_001.json
+```
+
+## Sample Data
+
+### prediction_001.json
+
+A BTC/USD prediction with:
+- Direction: up, 75% confidence, 24h horizon
+- Model version, data sources, feature count
+- Pre-computed canonical content hash
+
+### observation_001.json
+
+An observation recording the outcome:
+- Links to prediction via `prediction_ref`
+- Outcome: correct, actual direction: up, 2.3% return
+- Pre-computed canonical content hash (with placeholder prediction ref)
+
+## Canonical Hashing
+
+The content hash is computed as:
+
+1. Take all fields except `content_hash`
+2. Serialize with `json.dumps(data, sort_keys=True, separators=(',', ':'))`
+3. Compute SHA-256 of the UTF-8 encoded string
+
+This makes the hash deterministic regardless of:
+- JSON key ordering
+- Whitespace formatting
+- Platform differences
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `demo.sh` | Shell demo — verify, upload prediction + observation, download and verify |
+| `run_demo.py` | Python demo — same workflow with argparse support |
+| `create_memory_unit.py` | Helper: create and verify memory units with canonical hashing |
+| `prediction_001.json` | Sample prediction memory unit (BTC/USD, up, 75% confidence) |
+| `observation_001.json` | Sample observation (correct outcome, links to prediction) |

--- a/examples/06-market-memory/create_memory_unit.py
+++ b/examples/06-market-memory/create_memory_unit.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Market Memory Unit Generator
+
+Creates memory units (predictions, observations) with canonical content hashing.
+Canonical hashing ensures deterministic hash computation regardless of JSON key order.
+
+Canonical hash is computed over all fields of the unit content EXCEPT the
+content_hash field itself:
+    json.dumps(data, sort_keys=True, separators=(',', ':')) -> SHA-256
+
+Usage:
+    python create_memory_unit.py prediction --agent "agent-alpha" --market "BTC/USD"
+    python create_memory_unit.py observation --agent "agent-alpha" --market "BTC/USD" \\
+        --prediction-ref <swarm_hash>
+"""
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+
+
+def canonical_hash(data: dict) -> str:
+    """Compute SHA-256 over canonical JSON representation.
+
+    Excludes the 'content_hash' field from the hash computation.
+    Uses sorted keys and compact separators for determinism.
+    """
+    hashable = {k: v for k, v in data.items() if k != "content_hash"}
+    canonical = json.dumps(hashable, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def verify_hash(data: dict) -> bool:
+    """Verify that a memory unit's content_hash is correct."""
+    expected = canonical_hash(data)
+    return data.get("content_hash") == expected
+
+
+def create_prediction(agent_id: str, market: str, direction: str = "up",
+                      confidence: float = 0.75, horizon_hours: int = 24) -> dict:
+    """Create a prediction memory unit."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    unit = {
+        "type": "prediction",
+        "version": "1.0",
+        "agent_id": agent_id,
+        "market": market,
+        "timestamp": now,
+        "prediction": {
+            "direction": direction,
+            "confidence": confidence,
+            "horizon_hours": horizon_hours,
+            "reasoning": f"Technical analysis indicates {direction} movement "
+                         f"with {confidence:.0%} confidence over {horizon_hours}h"
+        },
+        "metadata": {
+            "model_version": "v2.1",
+            "data_sources": ["price_feed", "order_book", "sentiment"],
+            "features_used": 42
+        }
+    }
+    unit["content_hash"] = canonical_hash(unit)
+    return unit
+
+
+def create_observation(agent_id: str, market: str, prediction_ref: str,
+                       outcome: str = "correct", actual_direction: str = "up",
+                       return_pct: float = 2.3) -> dict:
+    """Create an observation memory unit that links to a prediction."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    unit = {
+        "type": "observation",
+        "version": "1.0",
+        "agent_id": agent_id,
+        "market": market,
+        "timestamp": now,
+        "prediction_ref": prediction_ref,
+        "observation": {
+            "outcome": outcome,
+            "actual_direction": actual_direction,
+            "return_pct": return_pct,
+            "evaluation_timestamp": now
+        },
+        "metadata": {
+            "evaluation_method": "price_comparison",
+            "data_source": "price_feed"
+        }
+    }
+    unit["content_hash"] = canonical_hash(unit)
+    return unit
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create market memory units with canonical hashing"
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Unit type to create")
+
+    # Prediction subcommand
+    pred = subparsers.add_parser("prediction", help="Create a prediction unit")
+    pred.add_argument("--agent", default="agent-alpha", help="Agent ID")
+    pred.add_argument("--market", default="BTC/USD", help="Market pair")
+    pred.add_argument("--direction", default="up", choices=["up", "down"])
+    pred.add_argument("--confidence", type=float, default=0.75)
+    pred.add_argument("--horizon", type=int, default=24, help="Horizon in hours")
+    pred.add_argument("--output", "-o", help="Output file path")
+
+    # Observation subcommand
+    obs = subparsers.add_parser("observation", help="Create an observation unit")
+    obs.add_argument("--agent", default="agent-alpha", help="Agent ID")
+    obs.add_argument("--market", default="BTC/USD", help="Market pair")
+    obs.add_argument("--prediction-ref", required=True, help="Swarm ref of prediction")
+    obs.add_argument("--outcome", default="correct", choices=["correct", "incorrect"])
+    obs.add_argument("--direction", default="up", choices=["up", "down"])
+    obs.add_argument("--return-pct", type=float, default=2.3)
+    obs.add_argument("--output", "-o", help="Output file path")
+
+    # Verify subcommand
+    verify = subparsers.add_parser("verify", help="Verify a memory unit's hash")
+    verify.add_argument("file", help="JSON file to verify")
+
+    args = parser.parse_args()
+
+    if args.command == "prediction":
+        unit = create_prediction(
+            args.agent, args.market, args.direction,
+            args.confidence, args.horizon
+        )
+        output = json.dumps(unit, indent=2)
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(output + "\n")
+            print(f"Prediction saved to {args.output}")
+        else:
+            print(output)
+        print(f"\nContent hash: {unit['content_hash']}")
+
+    elif args.command == "observation":
+        unit = create_observation(
+            args.agent, args.market, args.prediction_ref,
+            args.outcome, args.direction, args.return_pct
+        )
+        output = json.dumps(unit, indent=2)
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(output + "\n")
+            print(f"Observation saved to {args.output}")
+        else:
+            print(output)
+        print(f"\nContent hash: {unit['content_hash']}")
+
+    elif args.command == "verify":
+        with open(args.file) as f:
+            data = json.load(f)
+        if verify_hash(data):
+            print(f"PASS: Content hash verified for {args.file}")
+            print(f"  Hash: {data['content_hash']}")
+        else:
+            expected = canonical_hash(data)
+            print(f"FAIL: Content hash mismatch for {args.file}")
+            print(f"  Stored:   {data.get('content_hash', '(missing)')}")
+            print(f"  Expected: {expected}")
+            sys.exit(1)
+
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/06-market-memory/demo.sh
+++ b/examples/06-market-memory/demo.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Market Memory Demo
+#
+# Demonstrates market prediction memory units on Swarm:
+# 1. Verify canonical hash of a prediction memory unit
+# 2. Upload prediction with --std "MARKET-MEMORY-V1"
+# 3. Upload observation that links to the prediction
+# 4. Download both and verify canonical hashes
+#
+# Usage: ./demo.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PREDICTION_FILE="$SCRIPT_DIR/prediction_001.json"
+OBSERVATION_FILE="$SCRIPT_DIR/observation_001.json"
+DOWNLOAD_DIR="$SCRIPT_DIR/downloads"
+
+echo "========================================="
+echo "  Swarm Provenance CLI - Market Memory"
+echo "========================================="
+echo
+
+# --- Step 0: Check CLI is installed ---
+if ! command -v swarm-prov-upload &>/dev/null; then
+    echo "ERROR: swarm-prov-upload not found. Install with: pip install -e ."
+    exit 1
+fi
+
+echo "CLI version: $(swarm-prov-upload --version)"
+echo
+
+# --- Step 1: Verify canonical hash of prediction ---
+echo "--- Step 1: Verify prediction canonical hash ---"
+echo "Verifying: $PREDICTION_FILE"
+python3 "$SCRIPT_DIR/create_memory_unit.py" verify "$PREDICTION_FILE"
+echo
+
+# --- Step 2: Check gateway health ---
+echo "--- Step 2: Check gateway health ---"
+swarm-prov-upload health
+echo
+
+# --- Step 3: Upload prediction ---
+echo "--- Step 3: Upload prediction with --std MARKET-MEMORY-V1 ---"
+echo "File: $PREDICTION_FILE"
+echo "SHA256: $(shasum -a 256 "$PREDICTION_FILE" | cut -d' ' -f1)"
+echo
+
+echo "Uploading (trying pool first)..."
+UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$PREDICTION_FILE" --std "MARKET-MEMORY-V1" --usePool 2>&1) || {
+    echo "Pool not available, falling back to regular stamp purchase..."
+    UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$PREDICTION_FILE" --std "MARKET-MEMORY-V1" 2>&1)
+}
+echo "$UPLOAD_OUTPUT"
+
+PRED_REF=$(echo "$UPLOAD_OUTPUT" | grep -A1 "Swarm Reference Hash:" | tail -1 | tr -d '[:space:]')
+
+if [ -z "$PRED_REF" ] || [ ${#PRED_REF} -lt 64 ]; then
+    echo "ERROR: Could not extract Swarm reference for prediction."
+    exit 1
+fi
+
+echo
+echo "Prediction Reference: $PRED_REF"
+echo
+
+# --- Step 4: Update observation with prediction reference and upload ---
+echo "--- Step 4: Upload observation linking to prediction ---"
+
+# Create a temporary observation with the actual prediction Swarm reference
+TEMP_OBS=$(mktemp)
+python3 -c "
+import json, hashlib
+with open('$OBSERVATION_FILE') as f:
+    obs = json.load(f)
+obs['prediction_ref'] = '$PRED_REF'
+# Recompute canonical hash
+hashable = {k: v for k, v in obs.items() if k != 'content_hash'}
+canonical = json.dumps(hashable, sort_keys=True, separators=(',', ':'))
+obs['content_hash'] = hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+with open('$TEMP_OBS', 'w') as f:
+    json.dump(obs, f, indent=2)
+    f.write('\n')
+"
+
+echo "File: observation (with prediction_ref = $PRED_REF)"
+echo "SHA256: $(shasum -a 256 "$TEMP_OBS" | cut -d' ' -f1)"
+echo
+
+echo "Uploading (trying pool first)..."
+UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$TEMP_OBS" --std "MARKET-MEMORY-V1" --usePool 2>&1) || {
+    echo "Pool not available, falling back to regular stamp purchase..."
+    UPLOAD_OUTPUT=$(swarm-prov-upload upload --file "$TEMP_OBS" --std "MARKET-MEMORY-V1" 2>&1)
+}
+echo "$UPLOAD_OUTPUT"
+
+OBS_REF=$(echo "$UPLOAD_OUTPUT" | grep -A1 "Swarm Reference Hash:" | tail -1 | tr -d '[:space:]')
+rm -f "$TEMP_OBS"
+
+if [ -z "$OBS_REF" ] || [ ${#OBS_REF} -lt 64 ]; then
+    echo "ERROR: Could not extract Swarm reference for observation."
+    exit 1
+fi
+
+echo
+echo "Observation Reference: $OBS_REF"
+echo
+
+# --- Step 5: Download prediction and verify ---
+echo "--- Step 5: Download and verify prediction ---"
+rm -rf "$DOWNLOAD_DIR"
+mkdir -p "$DOWNLOAD_DIR"
+
+swarm-prov-upload download "$PRED_REF" --output-dir "$DOWNLOAD_DIR"
+echo
+
+DOWNLOADED_FILE=$(ls "$DOWNLOAD_DIR"/*.data 2>/dev/null | head -1)
+if [ -z "$DOWNLOADED_FILE" ]; then
+    DOWNLOADED_FILE=$(ls "$DOWNLOAD_DIR"/ | head -1)
+    DOWNLOADED_FILE="$DOWNLOAD_DIR/$DOWNLOADED_FILE"
+fi
+
+ORIGINAL_HASH=$(shasum -a 256 "$PREDICTION_FILE" | cut -d' ' -f1)
+DOWNLOADED_HASH=$(shasum -a 256 "$DOWNLOADED_FILE" | cut -d' ' -f1)
+
+echo "Original:   $ORIGINAL_HASH"
+echo "Downloaded: $DOWNLOADED_HASH"
+echo
+
+if [ "$ORIGINAL_HASH" = "$DOWNLOADED_HASH" ]; then
+    echo "PASS: Prediction data integrity verified."
+else
+    echo "FAIL: Prediction hash mismatch!"
+    exit 1
+fi
+
+# Verify canonical hash of downloaded prediction
+echo
+echo "Verifying canonical hash of downloaded prediction..."
+python3 "$SCRIPT_DIR/create_memory_unit.py" verify "$DOWNLOADED_FILE"
+
+echo
+echo "--- Demo complete ---"
+echo "Prediction Reference:  $PRED_REF"
+echo "Observation Reference: $OBS_REF"
+echo "The observation links back to the prediction via prediction_ref."
+echo "Both memory units use canonical hashing for content integrity."

--- a/examples/06-market-memory/observation_001.json
+++ b/examples/06-market-memory/observation_001.json
@@ -1,0 +1,19 @@
+{
+  "type": "observation",
+  "version": "1.0",
+  "agent_id": "agent-alpha",
+  "market": "BTC/USD",
+  "timestamp": "2025-06-16T08:00:00Z",
+  "prediction_ref": "PREDICTION_SWARM_REF_PLACEHOLDER",
+  "observation": {
+    "outcome": "correct",
+    "actual_direction": "up",
+    "return_pct": 2.3,
+    "evaluation_timestamp": "2025-06-16T08:00:00Z"
+  },
+  "metadata": {
+    "evaluation_method": "price_comparison",
+    "data_source": "price_feed"
+  },
+  "content_hash": "cea3c1a39e41292e0391310747f0cc120623979e7fe7bce6dcad4aeacb91b56a"
+}

--- a/examples/06-market-memory/prediction_001.json
+++ b/examples/06-market-memory/prediction_001.json
@@ -1,0 +1,19 @@
+{
+  "type": "prediction",
+  "version": "1.0",
+  "agent_id": "agent-alpha",
+  "market": "BTC/USD",
+  "timestamp": "2025-06-15T08:00:00Z",
+  "prediction": {
+    "direction": "up",
+    "confidence": 0.75,
+    "horizon_hours": 24,
+    "reasoning": "Technical analysis indicates up movement with 75% confidence over 24h"
+  },
+  "metadata": {
+    "model_version": "v2.1",
+    "data_sources": ["price_feed", "order_book", "sentiment"],
+    "features_used": 42
+  },
+  "content_hash": "c5bf979e6fc3a28771ed1e75cea8243b33e201c263f290551d4646c29ba1354c"
+}

--- a/examples/06-market-memory/run_demo.py
+++ b/examples/06-market-memory/run_demo.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Market Memory Demo - Python Version
+
+Demonstrates market prediction memory units on Swarm:
+1. Verify canonical hash of a prediction memory unit
+2. Upload prediction with --std "MARKET-MEMORY-V1"
+3. Create and upload observation linking to the prediction
+4. Download both and verify canonical hashes
+
+Usage:
+    python run_demo.py
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+
+# Import canonical hashing from create_memory_unit
+sys.path.insert(0, str(SCRIPT_DIR))
+from create_memory_unit import canonical_hash, verify_hash
+
+
+def sha256_file(path: str) -> str:
+    """Compute SHA-256 hash of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def run_cli(*args) -> subprocess.CompletedProcess:
+    """Run a swarm-prov-upload CLI command."""
+    cmd = ["swarm-prov-upload"] + list(args)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result
+
+
+def extract_swarm_ref(output: str) -> str:
+    """Extract Swarm reference hash from CLI output."""
+    lines = output.splitlines()
+    for i, line in enumerate(lines):
+        if "Swarm Reference Hash:" in line and i + 1 < len(lines):
+            ref = lines[i + 1].strip()
+            if len(ref) >= 64:
+                return ref
+    return ""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Market memory demo")
+    parser.add_argument(
+        "--prediction", "-p",
+        default=str(SCRIPT_DIR / "prediction_001.json"),
+        help="Prediction JSON file (default: prediction_001.json)",
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(args.prediction):
+        print(f"ERROR: File not found: {args.prediction}")
+        sys.exit(1)
+
+    print("=" * 55)
+    print("  Swarm Provenance CLI - Market Memory (Python)")
+    print("=" * 55)
+
+    # --- Step 1: Verify canonical hash ---
+    print("\n--- Step 1: Verify prediction canonical hash ---")
+    with open(args.prediction) as f:
+        prediction = json.load(f)
+
+    if verify_hash(prediction):
+        print(f"PASS: Canonical hash verified for prediction")
+        print(f"  Hash: {prediction['content_hash']}")
+    else:
+        print(f"FAIL: Canonical hash mismatch!")
+        sys.exit(1)
+
+    # --- Step 2: Check health ---
+    print("\n--- Step 2: Check gateway health ---")
+    result = run_cli("health")
+    if result.returncode != 0:
+        print(f"Gateway not available: {result.stderr or result.stdout}")
+        sys.exit(1)
+    print(result.stdout.strip())
+
+    # --- Step 3: Upload prediction ---
+    print("\n--- Step 3: Upload prediction with --std MARKET-MEMORY-V1 ---")
+    pred_hash = sha256_file(args.prediction)
+    print(f"File:   {args.prediction}")
+    print(f"SHA256: {pred_hash}")
+
+    print("\nUploading (trying pool first)...")
+    result = run_cli("upload", "--file", args.prediction, "--std", "MARKET-MEMORY-V1", "--usePool")
+    if result.returncode != 0:
+        print("Pool not available, falling back to regular stamp purchase...")
+        result = run_cli("upload", "--file", args.prediction, "--std", "MARKET-MEMORY-V1")
+        if result.returncode != 0:
+            print(f"Upload failed: {result.stderr or result.stdout}")
+            sys.exit(1)
+
+    print(result.stdout.strip())
+    pred_ref = extract_swarm_ref(result.stdout)
+    if not pred_ref:
+        print("Could not extract Swarm reference from output")
+        sys.exit(1)
+    print(f"\nPrediction Reference: {pred_ref}")
+
+    # --- Step 4: Create and upload observation ---
+    print("\n--- Step 4: Upload observation linking to prediction ---")
+
+    # Load the sample observation and update prediction_ref
+    obs_path = str(SCRIPT_DIR / "observation_001.json")
+    with open(obs_path) as f:
+        observation = json.load(f)
+
+    observation["prediction_ref"] = pred_ref
+    # Recompute canonical hash with the actual prediction reference
+    observation["content_hash"] = canonical_hash(observation)
+
+    # Write updated observation to temp file
+    temp_obs = str(SCRIPT_DIR / "observation_temp.json")
+    with open(temp_obs, "w") as f:
+        json.dump(observation, f, indent=2)
+        f.write("\n")
+
+    obs_hash = sha256_file(temp_obs)
+    print(f"Observation links to prediction: {pred_ref}")
+    print(f"SHA256: {obs_hash}")
+
+    print("\nUploading (trying pool first)...")
+    result = run_cli("upload", "--file", temp_obs, "--std", "MARKET-MEMORY-V1", "--usePool")
+    if result.returncode != 0:
+        print("Pool not available, falling back to regular stamp purchase...")
+        result = run_cli("upload", "--file", temp_obs, "--std", "MARKET-MEMORY-V1")
+        if result.returncode != 0:
+            print(f"Upload failed: {result.stderr or result.stdout}")
+            os.remove(temp_obs)
+            sys.exit(1)
+
+    print(result.stdout.strip())
+    obs_ref = extract_swarm_ref(result.stdout)
+    os.remove(temp_obs)
+
+    if not obs_ref:
+        print("Could not extract Swarm reference from output")
+        sys.exit(1)
+    print(f"\nObservation Reference: {obs_ref}")
+
+    # --- Step 5: Download and verify prediction ---
+    print("\n--- Step 5: Download and verify prediction ---")
+    download_dir = str(SCRIPT_DIR / "downloads")
+    os.makedirs(download_dir, exist_ok=True)
+    for f in os.listdir(download_dir):
+        os.remove(os.path.join(download_dir, f))
+
+    result = run_cli("download", pred_ref, "--output-dir", download_dir)
+    if result.returncode != 0:
+        print(f"Download failed: {result.stderr or result.stdout}")
+        sys.exit(1)
+    print(result.stdout.strip())
+
+    downloaded_files = os.listdir(download_dir)
+    if not downloaded_files:
+        print("ERROR: No files in download directory")
+        sys.exit(1)
+
+    data_files = [f for f in downloaded_files if f.endswith(".data")]
+    if data_files:
+        downloaded_file = os.path.join(download_dir, data_files[0])
+    else:
+        downloaded_file = os.path.join(download_dir, downloaded_files[0])
+
+    # Verify file hash
+    original_hash = sha256_file(args.prediction)
+    downloaded_hash = sha256_file(downloaded_file)
+    print(f"\nOriginal:   {original_hash}")
+    print(f"Downloaded: {downloaded_hash}")
+
+    if original_hash != downloaded_hash:
+        print("\nFAIL: Prediction hash mismatch!")
+        sys.exit(1)
+    print("\nPASS: Prediction data integrity verified.")
+
+    # Verify canonical hash of downloaded prediction
+    print("\nVerifying canonical hash of downloaded prediction...")
+    with open(downloaded_file) as f:
+        downloaded_pred = json.load(f)
+
+    if verify_hash(downloaded_pred):
+        print(f"PASS: Canonical hash verified.")
+    else:
+        print(f"FAIL: Canonical hash mismatch!")
+        sys.exit(1)
+
+    # --- Summary ---
+    print("\n--- Summary ---")
+    print(f"Prediction Reference:  {pred_ref}")
+    print(f"Observation Reference: {obs_ref}")
+    print(f"Prediction→Outcome chain: {pred_ref} ← {obs_ref}")
+    print("Both memory units use canonical hashing for content integrity.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,10 @@ Real-world usage examples for the Swarm Provenance CLI toolkit.
 | # | Example | Description |
 |---|---------|-------------|
 | [01](01-basic-upload-download/) | **Basic Upload/Download** | Upload a file, download it back, verify integrity |
+| [02](02-audit-trail/) | **Audit Trail** | Immutable compliance records with `--std "AUDIT-LOG-V1"` |
+| [03](03-scientific-data/) | **Scientific Data** | Research archival with `--std "PROV-O"` and `--duration 720` |
+| [05](05-encrypted-data/) | **Encrypted Data** | Pre-encrypt, upload with `--enc "AES-256-GCM"`, decrypt |
+| [06](06-market-memory/) | **Market Memory** | Canonical hashing, prediction→outcome linking |
 
 ## Directory Structure
 
@@ -35,10 +39,15 @@ examples/
     sample_generator.py        # Generate sample data files
     verify.py                  # Verification helpers
   01-basic-upload-download/    # Core upload/download workflow
-    README.md
-    demo.sh
-    sample.txt
-    run_demo.py
+    README.md, demo.sh, run_demo.py, sample.txt
+  02-audit-trail/              # Immutable compliance records
+    README.md, demo.sh, run_demo.py, audit_record_*.json
+  03-scientific-data/          # Research data archival
+    README.md, demo.sh, run_demo.py, dataset_metadata.json, experiment_results.csv
+  05-encrypted-data/           # Pre-encryption workflow
+    README.md, demo.sh, run_demo.py, sensitive_data.txt
+  06-market-memory/            # Prediction memory units
+    README.md, demo.sh, run_demo.py, create_memory_unit.py, prediction_001.json, observation_001.json
 ```
 
 ## Common Utilities

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -4,6 +4,10 @@ Unit tests verify:
 - sample_generator: text, JSON, CSV file generation
 - verify: SHA-256 hashing, file comparison, CLI output parsing
 - demo workflow: full upload/download/verify cycle with mocked CLI
+- 02-audit-trail: multi-record upload with --std AUDIT-LOG-V1
+- 03-scientific-data: PROV-O standard with --duration 720
+- 05-encrypted-data: encryption workflow with --enc AES-256-GCM
+- 06-market-memory: canonical hashing and prediction→observation linking
 
 Integration tests (marked @pytest.mark.gateway) run actual demos
 against a live gateway — skipped when gateway is unavailable.
@@ -24,6 +28,10 @@ import pytest
 # Add examples dir to path so we can import common modules
 EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
 DEMO_DIR = EXAMPLES_DIR / "01-basic-upload-download"
+AUDIT_DIR = EXAMPLES_DIR / "02-audit-trail"
+SCIENCE_DIR = EXAMPLES_DIR / "03-scientific-data"
+ENCRYPTED_DIR = EXAMPLES_DIR / "05-encrypted-data"
+MARKET_DIR = EXAMPLES_DIR / "06-market-memory"
 sys.path.insert(0, str(EXAMPLES_DIR))
 
 from common.sample_generator import generate_text_file, generate_json_file, generate_csv_file
@@ -487,6 +495,805 @@ class TestDemoPythonScript:
 
 
 # =============================================================================
+# EXAMPLE 02: AUDIT TRAIL TESTS
+# =============================================================================
+
+
+class TestAuditTrailShellScript:
+    """Tests for the 02-audit-trail bash demo script."""
+
+    def test_shell_script_is_valid_bash(self):
+        result = subprocess.run(
+            ["bash", "-n", str(AUDIT_DIR / "demo.sh")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"Bash syntax error: {result.stderr}"
+
+    def test_shell_script_is_executable(self):
+        assert os.access(str(AUDIT_DIR / "demo.sh"), os.X_OK)
+
+    def test_shell_script_has_shebang(self):
+        content = (AUDIT_DIR / "demo.sh").read_text()
+        assert content.startswith("#!/usr/bin/env bash")
+
+    def test_shell_script_uses_strict_mode(self):
+        content = (AUDIT_DIR / "demo.sh").read_text()
+        assert "set -euo pipefail" in content
+
+    def test_shell_script_uses_audit_std(self):
+        content = (AUDIT_DIR / "demo.sh").read_text()
+        assert '--std "AUDIT-LOG-V1"' in content
+
+
+class TestAuditTrailSampleFiles:
+    """Tests for audit trail sample JSON files."""
+
+    @pytest.mark.parametrize("filename", [
+        "audit_record_001.json",
+        "audit_record_002.json",
+        "audit_record_003.json",
+    ])
+    def test_audit_record_exists(self, filename):
+        assert (AUDIT_DIR / filename).exists()
+
+    @pytest.mark.parametrize("filename", [
+        "audit_record_001.json",
+        "audit_record_002.json",
+        "audit_record_003.json",
+    ])
+    def test_audit_record_is_valid_json(self, filename):
+        data = json.loads((AUDIT_DIR / filename).read_text())
+        assert "event_type" in data
+        assert "event_id" in data
+        assert "timestamp" in data
+        assert "actor" in data
+        assert "action" in data
+        assert "compliance" in data
+
+    def test_audit_records_have_distinct_event_types(self):
+        event_types = set()
+        for filename in ["audit_record_001.json", "audit_record_002.json", "audit_record_003.json"]:
+            data = json.loads((AUDIT_DIR / filename).read_text())
+            event_types.add(data["event_type"])
+        assert len(event_types) == 3
+
+
+class TestAuditTrailPythonDemo:
+    """Tests for 02-audit-trail/run_demo.py with mocked CLI."""
+
+    def _load_demo(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "audit_demo", str(AUDIT_DIR / "run_demo.py")
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_full_workflow(self, tmp_path, monkeypatch):
+        """Test uploading 3 audit records, downloading and verifying one."""
+        # Copy sample files to tmp_path
+        for f in ["audit_record_001.json", "audit_record_002.json", "audit_record_003.json"]:
+            content = (AUDIT_DIR / f).read_bytes()
+            (tmp_path / f).write_bytes(content)
+
+        upload_count = {"n": 0}
+
+        def mock_subprocess_run(cmd, **kwargs):
+            subcmd = _get_cli_subcommand(cmd)
+            if subcmd == "health":
+                return _make_completed_process(stdout="Healthy\n")
+            elif subcmd == "upload":
+                upload_count["n"] += 1
+                # Verify --std flag is present
+                cmd_str = " ".join(str(c) for c in cmd)
+                assert "AUDIT-LOG-V1" in cmd_str
+                return _make_completed_process(stdout=_upload_success_output())
+            elif subcmd == "download":
+                dl_dir = tmp_path / "downloads"
+                dl_dir.mkdir(exist_ok=True)
+                # Copy the first audit record as downloaded content
+                content = (tmp_path / "audit_record_001.json").read_bytes()
+                (dl_dir / f"{FAKE_HASH}.data").write_bytes(content)
+                return _make_completed_process(stdout="Downloaded.\n")
+            return _make_completed_process()
+
+        mod = self._load_demo()
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py", "--records",
+            "audit_record_001.json", "audit_record_002.json", "audit_record_003.json"
+        ])
+        mod.main()
+        # Should upload 3 records (pool succeeds)
+        assert upload_count["n"] == 3
+
+    def test_pool_fallback(self, tmp_path, monkeypatch):
+        """Test fallback when pool is unavailable."""
+        (tmp_path / "audit_record_001.json").write_bytes(
+            (AUDIT_DIR / "audit_record_001.json").read_bytes()
+        )
+
+        upload_calls = {"n": 0}
+
+        def mock_subprocess_run(cmd, **kwargs):
+            subcmd = _get_cli_subcommand(cmd)
+            if subcmd == "health":
+                return _make_completed_process(stdout="Healthy\n")
+            elif subcmd == "upload":
+                upload_calls["n"] += 1
+                cmd_str = " ".join(str(c) for c in cmd)
+                if "--usePool" in cmd_str:
+                    return _make_completed_process(returncode=1, stderr="No pool")
+                return _make_completed_process(stdout=_upload_success_output())
+            elif subcmd == "download":
+                dl_dir = tmp_path / "downloads"
+                dl_dir.mkdir(exist_ok=True)
+                (dl_dir / f"{FAKE_HASH}.data").write_bytes(
+                    (tmp_path / "audit_record_001.json").read_bytes()
+                )
+                return _make_completed_process(stdout="Downloaded.\n")
+            return _make_completed_process()
+
+        mod = self._load_demo()
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py", "--records", "audit_record_001.json"
+        ])
+        mod.main()
+        # Pool fail + fallback = 2 upload calls
+        assert upload_calls["n"] == 2
+
+    def test_upload_failure_exits(self, tmp_path, monkeypatch):
+        """Test that total upload failure exits with code 1."""
+        (tmp_path / "audit_record_001.json").write_text('{"test": true}')
+
+        def mock_subprocess_run(cmd, **kwargs):
+            subcmd = _get_cli_subcommand(cmd)
+            if subcmd == "health":
+                return _make_completed_process(stdout="Healthy\n")
+            elif subcmd == "upload":
+                return _make_completed_process(returncode=1, stderr="Failed")
+            return _make_completed_process()
+
+        mod = self._load_demo()
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py", "--records", "audit_record_001.json"
+        ])
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+        assert exc_info.value.code == 1
+
+    def test_hash_mismatch_exits(self, tmp_path, monkeypatch):
+        """Test that hash mismatch on download exits with code 1."""
+        (tmp_path / "audit_record_001.json").write_bytes(b"original content")
+
+        def mock_subprocess_run(cmd, **kwargs):
+            subcmd = _get_cli_subcommand(cmd)
+            if subcmd == "health":
+                return _make_completed_process(stdout="Healthy\n")
+            elif subcmd == "upload":
+                return _make_completed_process(stdout=_upload_success_output())
+            elif subcmd == "download":
+                dl_dir = tmp_path / "downloads"
+                dl_dir.mkdir(exist_ok=True)
+                (dl_dir / f"{FAKE_HASH}.data").write_bytes(b"different content")
+                return _make_completed_process(stdout="Downloaded.\n")
+            return _make_completed_process()
+
+        mod = self._load_demo()
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py", "--records", "audit_record_001.json"
+        ])
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+        assert exc_info.value.code == 1
+
+
+# =============================================================================
+# EXAMPLE 03: SCIENTIFIC DATA TESTS
+# =============================================================================
+
+
+class TestScientificDataShellScript:
+    """Tests for the 03-scientific-data bash demo script."""
+
+    def test_shell_script_is_valid_bash(self):
+        result = subprocess.run(
+            ["bash", "-n", str(SCIENCE_DIR / "demo.sh")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"Bash syntax error: {result.stderr}"
+
+    def test_shell_script_is_executable(self):
+        assert os.access(str(SCIENCE_DIR / "demo.sh"), os.X_OK)
+
+    def test_shell_script_has_shebang(self):
+        content = (SCIENCE_DIR / "demo.sh").read_text()
+        assert content.startswith("#!/usr/bin/env bash")
+
+    def test_shell_script_uses_strict_mode(self):
+        content = (SCIENCE_DIR / "demo.sh").read_text()
+        assert "set -euo pipefail" in content
+
+    def test_shell_script_uses_prov_o_std(self):
+        content = (SCIENCE_DIR / "demo.sh").read_text()
+        assert '--std "PROV-O"' in content
+
+    def test_shell_script_uses_duration_720(self):
+        content = (SCIENCE_DIR / "demo.sh").read_text()
+        assert "--duration 720" in content
+
+
+class TestScientificDataSampleFiles:
+    """Tests for scientific data sample files."""
+
+    def test_metadata_exists(self):
+        assert (SCIENCE_DIR / "dataset_metadata.json").exists()
+
+    def test_metadata_is_valid_json(self):
+        data = json.loads((SCIENCE_DIR / "dataset_metadata.json").read_text())
+        assert "title" in data
+        assert "experiment" in data
+        assert "methodology" in data
+        assert data["prov_standard"] == "PROV-O"
+
+    def test_csv_exists(self):
+        assert (SCIENCE_DIR / "experiment_results.csv").exists()
+
+    def test_csv_has_correct_structure(self):
+        with open(str(SCIENCE_DIR / "experiment_results.csv")) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 8
+        expected_cols = {"timestamp", "station_id", "temperature_c", "humidity_pct", "status"}
+        assert set(rows[0].keys()) == expected_cols
+
+    def test_csv_has_valid_data(self):
+        with open(str(SCIENCE_DIR / "experiment_results.csv")) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        for row in rows:
+            float(row["temperature_c"])  # Should not raise
+            float(row["humidity_pct"])
+            assert row["status"] in ("normal", "warning")
+
+
+class TestScientificDataPythonDemo:
+    """Tests for 03-scientific-data/run_demo.py with mocked CLI."""
+
+    def _load_demo(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "science_demo", str(SCIENCE_DIR / "run_demo.py")
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_full_workflow(self, tmp_path, monkeypatch):
+        """Test uploading metadata and CSV, downloading and verifying CSV."""
+        # Copy sample files
+        for f in ["dataset_metadata.json", "experiment_results.csv"]:
+            (tmp_path / f).write_bytes((SCIENCE_DIR / f).read_bytes())
+
+        upload_count = {"n": 0}
+
+        def mock_subprocess_run(cmd, **kwargs):
+            subcmd = _get_cli_subcommand(cmd)
+            if subcmd == "health":
+                return _make_completed_process(stdout="Healthy\n")
+            elif subcmd == "upload":
+                upload_count["n"] += 1
+                cmd_str = " ".join(str(c) for c in cmd)
+                assert "PROV-O" in cmd_str
+                return _make_completed_process(stdout=_upload_success_output())
+            elif subcmd == "download":
+                dl_dir = tmp_path / "downloads"
+                dl_dir.mkdir(exist_ok=True)
+                (dl_dir / f"{FAKE_HASH}.data").write_bytes(
+                    (tmp_path / "experiment_results.csv").read_bytes()
+                )
+                return _make_completed_process(stdout="Downloaded.\n")
+            return _make_completed_process()
+
+        mod = self._load_demo()
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py",
+            "--metadata", str(tmp_path / "dataset_metadata.json"),
+            "--results", str(tmp_path / "experiment_results.csv"),
+        ])
+        mod.main()
+        # metadata upload + CSV upload = 2 uploads (pool succeeds both times)
+        assert upload_count["n"] == 2
+
+    def test_duration_fallback(self, tmp_path, monkeypatch):
+        """Test that upload falls back when duration 720 is not available."""
+        for f in ["dataset_metadata.json", "experiment_results.csv"]:
+            (tmp_path / f).write_bytes((SCIENCE_DIR / f).read_bytes())
+
+        upload_attempts = {"n": 0}
+
+        def mock_subprocess_run(cmd, **kwargs):
+            subcmd = _get_cli_subcommand(cmd)
+            if subcmd == "health":
+                return _make_completed_process(stdout="Healthy\n")
+            elif subcmd == "upload":
+                upload_attempts["n"] += 1
+                cmd_str = " ".join(str(c) for c in cmd)
+                if "--duration" in cmd_str:
+                    return _make_completed_process(returncode=1, stderr="Duration not available")
+                return _make_completed_process(stdout=_upload_success_output())
+            elif subcmd == "download":
+                dl_dir = tmp_path / "downloads"
+                dl_dir.mkdir(exist_ok=True)
+                (dl_dir / f"{FAKE_HASH}.data").write_bytes(
+                    (tmp_path / "experiment_results.csv").read_bytes()
+                )
+                return _make_completed_process(stdout="Downloaded.\n")
+            return _make_completed_process()
+
+        mod = self._load_demo()
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py",
+            "--metadata", str(tmp_path / "dataset_metadata.json"),
+            "--results", str(tmp_path / "experiment_results.csv"),
+        ])
+        mod.main()
+        # Duration attempts fail (pool + no-pool), then fallback without duration succeeds
+        assert upload_attempts["n"] >= 3
+
+    def test_missing_file_exits(self, tmp_path, monkeypatch):
+        """Test exit when metadata file doesn't exist."""
+        mod = self._load_demo()
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py",
+            "--metadata", str(tmp_path / "nonexistent.json"),
+            "--results", str(tmp_path / "also_missing.csv"),
+        ])
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+        assert exc_info.value.code == 1
+
+
+# =============================================================================
+# EXAMPLE 05: ENCRYPTED DATA TESTS
+# =============================================================================
+
+
+class TestEncryptedDataShellScript:
+    """Tests for the 05-encrypted-data bash demo script."""
+
+    def test_shell_script_is_valid_bash(self):
+        result = subprocess.run(
+            ["bash", "-n", str(ENCRYPTED_DIR / "demo.sh")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"Bash syntax error: {result.stderr}"
+
+    def test_shell_script_is_executable(self):
+        assert os.access(str(ENCRYPTED_DIR / "demo.sh"), os.X_OK)
+
+    def test_shell_script_has_shebang(self):
+        content = (ENCRYPTED_DIR / "demo.sh").read_text()
+        assert content.startswith("#!/usr/bin/env bash")
+
+    def test_shell_script_uses_strict_mode(self):
+        content = (ENCRYPTED_DIR / "demo.sh").read_text()
+        assert "set -euo pipefail" in content
+
+    def test_shell_script_uses_enc_flag(self):
+        content = (ENCRYPTED_DIR / "demo.sh").read_text()
+        assert '--enc "AES-256-GCM"' in content
+
+
+class TestEncryptedDataSampleFiles:
+    """Tests for encrypted data sample files."""
+
+    def test_sensitive_data_exists(self):
+        assert (ENCRYPTED_DIR / "sensitive_data.txt").exists()
+
+    def test_sensitive_data_has_content(self):
+        content = (ENCRYPTED_DIR / "sensitive_data.txt").read_text()
+        assert len(content) > 0
+        assert "Patient" in content or "CONFIDENTIAL" in content
+
+
+class TestEncryptedDataPythonDemo:
+    """Tests for 05-encrypted-data/run_demo.py with mocked CLI."""
+
+    def _load_demo(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "encrypted_demo", str(ENCRYPTED_DIR / "run_demo.py")
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_xor_encrypt_decrypt_roundtrip(self):
+        """XOR cipher should be symmetric."""
+        mod = self._load_demo()
+        original = b"Hello, this is sensitive data!"
+        key = os.urandom(32)
+        encrypted = mod.xor_encrypt(original, key)
+        assert encrypted != original
+        decrypted = mod.xor_encrypt(encrypted, key)
+        assert decrypted == original
+
+    def test_xor_encrypt_different_with_different_key(self):
+        """Different keys should produce different ciphertext."""
+        mod = self._load_demo()
+        original = b"Same plaintext"
+        encrypted1 = mod.xor_encrypt(original, b"key1" * 8)
+        encrypted2 = mod.xor_encrypt(original, b"key2" * 8)
+        assert encrypted1 != encrypted2
+
+    def test_full_workflow(self, tmp_path, monkeypatch):
+        """Test encrypt, upload, download, verify, decrypt workflow."""
+        sample_content = b"Sensitive patient record data"
+        sample_file = tmp_path / "sensitive_data.txt"
+        sample_file.write_bytes(sample_content)
+
+        # Track what encrypted content was uploaded
+        uploaded_content = {}
+
+        def mock_subprocess_run(cmd, **kwargs):
+            subcmd = _get_cli_subcommand(cmd)
+            if subcmd == "health":
+                return _make_completed_process(stdout="Healthy\n")
+            elif subcmd == "upload":
+                cmd_str = " ".join(str(c) for c in cmd)
+                assert "AES-256-GCM" in cmd_str
+                # Read the encrypted file that was uploaded
+                for i, c in enumerate(cmd):
+                    if str(c) == "--file" and i + 1 < len(cmd):
+                        uploaded_content["data"] = Path(cmd[i + 1]).read_bytes()
+                return _make_completed_process(stdout=_upload_success_output())
+            elif subcmd == "download":
+                dl_dir = tmp_path / "downloads"
+                dl_dir.mkdir(exist_ok=True)
+                # Return the encrypted content
+                (dl_dir / f"{FAKE_HASH}.data").write_bytes(
+                    uploaded_content.get("data", b"")
+                )
+                return _make_completed_process(stdout="Downloaded.\n")
+            return _make_completed_process()
+
+        mod = self._load_demo()
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py", "--file", str(sample_file)
+        ])
+        mod.main()
+
+    def test_upload_failure_exits(self, tmp_path, monkeypatch):
+        """Test exit when upload fails."""
+        sample_file = tmp_path / "sensitive_data.txt"
+        sample_file.write_bytes(b"test data")
+
+        def mock_subprocess_run(cmd, **kwargs):
+            subcmd = _get_cli_subcommand(cmd)
+            if subcmd == "health":
+                return _make_completed_process(stdout="Healthy\n")
+            elif subcmd == "upload":
+                return _make_completed_process(returncode=1, stderr="Failed")
+            return _make_completed_process()
+
+        mod = self._load_demo()
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py", "--file", str(sample_file)
+        ])
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+        assert exc_info.value.code == 1
+
+    def test_encrypted_payload_mismatch_exits(self, tmp_path, monkeypatch):
+        """Test exit when downloaded encrypted payload doesn't match."""
+        sample_file = tmp_path / "sensitive_data.txt"
+        sample_file.write_bytes(b"test data")
+
+        def mock_subprocess_run(cmd, **kwargs):
+            subcmd = _get_cli_subcommand(cmd)
+            if subcmd == "health":
+                return _make_completed_process(stdout="Healthy\n")
+            elif subcmd == "upload":
+                return _make_completed_process(stdout=_upload_success_output())
+            elif subcmd == "download":
+                dl_dir = tmp_path / "downloads"
+                dl_dir.mkdir(exist_ok=True)
+                (dl_dir / f"{FAKE_HASH}.data").write_bytes(b"corrupted data")
+                return _make_completed_process(stdout="Downloaded.\n")
+            return _make_completed_process()
+
+        mod = self._load_demo()
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py", "--file", str(sample_file)
+        ])
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+        assert exc_info.value.code == 1
+
+    def test_missing_file_exits(self, tmp_path, monkeypatch):
+        """Test exit when input file doesn't exist."""
+        mod = self._load_demo()
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py", "--file", str(tmp_path / "nonexistent.txt")
+        ])
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+        assert exc_info.value.code == 1
+
+
+# =============================================================================
+# EXAMPLE 06: MARKET MEMORY TESTS
+# =============================================================================
+
+
+class TestMarketMemoryShellScript:
+    """Tests for the 06-market-memory bash demo script."""
+
+    def test_shell_script_is_valid_bash(self):
+        result = subprocess.run(
+            ["bash", "-n", str(MARKET_DIR / "demo.sh")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"Bash syntax error: {result.stderr}"
+
+    def test_shell_script_is_executable(self):
+        assert os.access(str(MARKET_DIR / "demo.sh"), os.X_OK)
+
+    def test_shell_script_has_shebang(self):
+        content = (MARKET_DIR / "demo.sh").read_text()
+        assert content.startswith("#!/usr/bin/env bash")
+
+    def test_shell_script_uses_strict_mode(self):
+        content = (MARKET_DIR / "demo.sh").read_text()
+        assert "set -euo pipefail" in content
+
+    def test_shell_script_uses_market_memory_std(self):
+        content = (MARKET_DIR / "demo.sh").read_text()
+        assert '--std "MARKET-MEMORY-V1"' in content
+
+
+class TestMarketMemorySampleFiles:
+    """Tests for market memory sample JSON files."""
+
+    def test_prediction_exists(self):
+        assert (MARKET_DIR / "prediction_001.json").exists()
+
+    def test_observation_exists(self):
+        assert (MARKET_DIR / "observation_001.json").exists()
+
+    def test_create_memory_unit_exists(self):
+        assert (MARKET_DIR / "create_memory_unit.py").exists()
+
+    def test_prediction_is_valid_json(self):
+        data = json.loads((MARKET_DIR / "prediction_001.json").read_text())
+        assert data["type"] == "prediction"
+        assert data["version"] == "1.0"
+        assert "agent_id" in data
+        assert "market" in data
+        assert "prediction" in data
+        assert "content_hash" in data
+
+    def test_observation_is_valid_json(self):
+        data = json.loads((MARKET_DIR / "observation_001.json").read_text())
+        assert data["type"] == "observation"
+        assert data["version"] == "1.0"
+        assert "prediction_ref" in data
+        assert "observation" in data
+        assert "content_hash" in data
+
+    def test_prediction_has_valid_canonical_hash(self):
+        """The pre-computed content_hash should match the canonical hash."""
+        data = json.loads((MARKET_DIR / "prediction_001.json").read_text())
+        hashable = {k: v for k, v in data.items() if k != "content_hash"}
+        canonical = json.dumps(hashable, sort_keys=True, separators=(",", ":"))
+        expected = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        assert data["content_hash"] == expected
+
+    def test_observation_has_valid_canonical_hash(self):
+        """The pre-computed content_hash should match the canonical hash."""
+        data = json.loads((MARKET_DIR / "observation_001.json").read_text())
+        hashable = {k: v for k, v in data.items() if k != "content_hash"}
+        canonical = json.dumps(hashable, sort_keys=True, separators=(",", ":"))
+        expected = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        assert data["content_hash"] == expected
+
+
+class TestMarketMemoryCreateUnit:
+    """Tests for create_memory_unit.py canonical hashing functions."""
+
+    def _load_module(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "create_memory_unit", str(MARKET_DIR / "create_memory_unit.py")
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_canonical_hash_deterministic(self):
+        """Same data should always produce the same hash."""
+        mod = self._load_module()
+        data = {"b": 2, "a": 1, "c": 3}
+        assert mod.canonical_hash(data) == mod.canonical_hash(data)
+
+    def test_canonical_hash_ignores_key_order(self):
+        """Hash should be the same regardless of dict key order."""
+        mod = self._load_module()
+        data1 = {"a": 1, "b": 2}
+        data2 = {"b": 2, "a": 1}
+        assert mod.canonical_hash(data1) == mod.canonical_hash(data2)
+
+    def test_canonical_hash_excludes_content_hash(self):
+        """content_hash field should be excluded from hash computation."""
+        mod = self._load_module()
+        data_without = {"a": 1, "b": 2}
+        data_with = {"a": 1, "b": 2, "content_hash": "should_be_excluded"}
+        assert mod.canonical_hash(data_without) == mod.canonical_hash(data_with)
+
+    def test_verify_hash_valid(self):
+        """verify_hash should return True for correctly hashed data."""
+        mod = self._load_module()
+        data = {"type": "test", "value": 42}
+        data["content_hash"] = mod.canonical_hash(data)
+        assert mod.verify_hash(data) is True
+
+    def test_verify_hash_invalid(self):
+        """verify_hash should return False for tampered data."""
+        mod = self._load_module()
+        data = {"type": "test", "value": 42}
+        data["content_hash"] = "0000000000000000000000000000000000000000000000000000000000000000"
+        assert mod.verify_hash(data) is False
+
+    def test_create_prediction(self):
+        """create_prediction should return a valid unit with content_hash."""
+        mod = self._load_module()
+        pred = mod.create_prediction("agent-test", "ETH/USD", "down", 0.80, 12)
+        assert pred["type"] == "prediction"
+        assert pred["agent_id"] == "agent-test"
+        assert pred["market"] == "ETH/USD"
+        assert pred["prediction"]["direction"] == "down"
+        assert "content_hash" in pred
+        assert mod.verify_hash(pred) is True
+
+    def test_create_observation(self):
+        """create_observation should return a valid unit linking to prediction."""
+        mod = self._load_module()
+        obs = mod.create_observation(
+            "agent-test", "ETH/USD", "abc123" * 11,
+            "incorrect", "down", -1.5
+        )
+        assert obs["type"] == "observation"
+        assert obs["prediction_ref"] == "abc123" * 11
+        assert obs["observation"]["outcome"] == "incorrect"
+        assert "content_hash" in obs
+        assert mod.verify_hash(obs) is True
+
+    def test_verify_sample_prediction(self):
+        """Verify the shipped prediction_001.json with the module."""
+        mod = self._load_module()
+        data = json.loads((MARKET_DIR / "prediction_001.json").read_text())
+        assert mod.verify_hash(data) is True
+
+    def test_verify_sample_observation(self):
+        """Verify the shipped observation_001.json with the module."""
+        mod = self._load_module()
+        data = json.loads((MARKET_DIR / "observation_001.json").read_text())
+        assert mod.verify_hash(data) is True
+
+
+class TestMarketMemoryPythonDemo:
+    """Tests for 06-market-memory/run_demo.py with mocked CLI."""
+
+    def _load_demo(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "market_demo", str(MARKET_DIR / "run_demo.py")
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_full_workflow(self, tmp_path, monkeypatch):
+        """Test prediction upload, observation upload, download and verify."""
+        # Copy sample files
+        for f in ["prediction_001.json", "observation_001.json", "create_memory_unit.py"]:
+            (tmp_path / f).write_bytes((MARKET_DIR / f).read_bytes())
+
+        upload_count = {"n": 0}
+
+        def mock_subprocess_run(cmd, **kwargs):
+            subcmd = _get_cli_subcommand(cmd)
+            if subcmd == "health":
+                return _make_completed_process(stdout="Healthy\n")
+            elif subcmd == "upload":
+                upload_count["n"] += 1
+                cmd_str = " ".join(str(c) for c in cmd)
+                assert "MARKET-MEMORY-V1" in cmd_str
+                return _make_completed_process(stdout=_upload_success_output())
+            elif subcmd == "download":
+                dl_dir = tmp_path / "downloads"
+                dl_dir.mkdir(exist_ok=True)
+                (dl_dir / f"{FAKE_HASH}.data").write_bytes(
+                    (tmp_path / "prediction_001.json").read_bytes()
+                )
+                return _make_completed_process(stdout="Downloaded.\n")
+            return _make_completed_process()
+
+        mod = self._load_demo()
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+        mod.SCRIPT_DIR = tmp_path
+        # Also patch sys.path so the import of create_memory_unit works from tmp_path
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py", "--prediction", str(tmp_path / "prediction_001.json")
+        ])
+        mod.main()
+        # prediction + observation = 2 uploads
+        assert upload_count["n"] == 2
+
+    def test_upload_failure_exits(self, tmp_path, monkeypatch):
+        """Test exit when prediction upload fails."""
+        for f in ["prediction_001.json", "observation_001.json", "create_memory_unit.py"]:
+            (tmp_path / f).write_bytes((MARKET_DIR / f).read_bytes())
+
+        def mock_subprocess_run(cmd, **kwargs):
+            subcmd = _get_cli_subcommand(cmd)
+            if subcmd == "health":
+                return _make_completed_process(stdout="Healthy\n")
+            elif subcmd == "upload":
+                return _make_completed_process(returncode=1, stderr="Failed")
+            return _make_completed_process()
+
+        mod = self._load_demo()
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py", "--prediction", str(tmp_path / "prediction_001.json")
+        ])
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+        assert exc_info.value.code == 1
+
+    def test_missing_prediction_file_exits(self, tmp_path, monkeypatch):
+        """Test exit when prediction file doesn't exist."""
+        # Copy create_memory_unit.py so import works
+        (tmp_path / "create_memory_unit.py").write_bytes(
+            (MARKET_DIR / "create_memory_unit.py").read_bytes()
+        )
+        mod = self._load_demo()
+        mod.SCRIPT_DIR = tmp_path
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(sys, "argv", [
+            "run_demo.py", "--prediction", str(tmp_path / "nonexistent.json")
+        ])
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+        assert exc_info.value.code == 1
+
+
+# =============================================================================
 # GATEWAY INTEGRATION TESTS — run actual demos
 # =============================================================================
 
@@ -588,5 +1395,169 @@ class TestDemoIntegration:
         )
         assert result.returncode == 0, (
             f"Shell demo failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "PASS" in result.stdout
+
+
+@pytest.mark.integration
+@pytest.mark.gateway
+class TestAuditTrailIntegration:
+    """Integration tests for 02-audit-trail demos."""
+
+    @skip_if_no_gateway_upload
+    def test_python_demo_e2e(self):
+        cli_path = _venv_cli_path()
+        venv_python = str(Path(__file__).parent.parent / ".venv" / "bin" / "python3")
+        env = os.environ.copy()
+        env["PATH"] = str(Path(cli_path).parent) + ":" + env.get("PATH", "")
+
+        result = subprocess.run(
+            [venv_python, str(AUDIT_DIR / "run_demo.py")],
+            capture_output=True, text=True,
+            timeout=300,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"Audit trail demo failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "PASS" in result.stdout
+
+    @skip_if_no_gateway_upload
+    def test_shell_demo_e2e(self):
+        cli_path = _venv_cli_path()
+        env = os.environ.copy()
+        env["PATH"] = str(Path(cli_path).parent) + ":" + env.get("PATH", "")
+
+        result = subprocess.run(
+            ["bash", str(AUDIT_DIR / "demo.sh")],
+            capture_output=True, text=True,
+            timeout=300,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"Audit trail shell demo failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "PASS" in result.stdout
+
+
+@pytest.mark.integration
+@pytest.mark.gateway
+class TestScientificDataIntegration:
+    """Integration tests for 03-scientific-data demos."""
+
+    @skip_if_no_gateway_upload
+    def test_python_demo_e2e(self):
+        cli_path = _venv_cli_path()
+        venv_python = str(Path(__file__).parent.parent / ".venv" / "bin" / "python3")
+        env = os.environ.copy()
+        env["PATH"] = str(Path(cli_path).parent) + ":" + env.get("PATH", "")
+
+        result = subprocess.run(
+            [venv_python, str(SCIENCE_DIR / "run_demo.py")],
+            capture_output=True, text=True,
+            timeout=300,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"Scientific data demo failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "PASS" in result.stdout
+
+    @skip_if_no_gateway_upload
+    def test_shell_demo_e2e(self):
+        cli_path = _venv_cli_path()
+        env = os.environ.copy()
+        env["PATH"] = str(Path(cli_path).parent) + ":" + env.get("PATH", "")
+
+        result = subprocess.run(
+            ["bash", str(SCIENCE_DIR / "demo.sh")],
+            capture_output=True, text=True,
+            timeout=300,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"Scientific data shell demo failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "PASS" in result.stdout
+
+
+@pytest.mark.integration
+@pytest.mark.gateway
+class TestEncryptedDataIntegration:
+    """Integration tests for 05-encrypted-data demos."""
+
+    @skip_if_no_gateway_upload
+    def test_python_demo_e2e(self):
+        cli_path = _venv_cli_path()
+        venv_python = str(Path(__file__).parent.parent / ".venv" / "bin" / "python3")
+        env = os.environ.copy()
+        env["PATH"] = str(Path(cli_path).parent) + ":" + env.get("PATH", "")
+
+        result = subprocess.run(
+            [venv_python, str(ENCRYPTED_DIR / "run_demo.py")],
+            capture_output=True, text=True,
+            timeout=300,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"Encrypted data demo failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "PASS" in result.stdout
+
+    @skip_if_no_gateway_upload
+    def test_shell_demo_e2e(self):
+        cli_path = _venv_cli_path()
+        env = os.environ.copy()
+        env["PATH"] = str(Path(cli_path).parent) + ":" + env.get("PATH", "")
+
+        result = subprocess.run(
+            ["bash", str(ENCRYPTED_DIR / "demo.sh")],
+            capture_output=True, text=True,
+            timeout=300,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"Encrypted data shell demo failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "PASS" in result.stdout
+
+
+@pytest.mark.integration
+@pytest.mark.gateway
+class TestMarketMemoryIntegration:
+    """Integration tests for 06-market-memory demos."""
+
+    @skip_if_no_gateway_upload
+    def test_python_demo_e2e(self):
+        cli_path = _venv_cli_path()
+        venv_python = str(Path(__file__).parent.parent / ".venv" / "bin" / "python3")
+        env = os.environ.copy()
+        env["PATH"] = str(Path(cli_path).parent) + ":" + env.get("PATH", "")
+
+        result = subprocess.run(
+            [venv_python, str(MARKET_DIR / "run_demo.py")],
+            capture_output=True, text=True,
+            timeout=300,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"Market memory demo failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "PASS" in result.stdout
+
+    @skip_if_no_gateway_upload
+    def test_shell_demo_e2e(self):
+        cli_path = _venv_cli_path()
+        env = os.environ.copy()
+        env["PATH"] = str(Path(cli_path).parent) + ":" + env.get("PATH", "")
+
+        result = subprocess.run(
+            ["bash", str(MARKET_DIR / "demo.sh")],
+            capture_output=True, text=True,
+            timeout=300,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"Market memory shell demo failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
         )
         assert "PASS" in result.stdout


### PR DESCRIPTION
## Summary

- Add 4 domain-specific examples (#21, #22, #24, #25) following the established pattern from `01-basic-upload-download`
- **02-audit-trail**: immutable compliance records with `--std "AUDIT-LOG-V1"` — uploads 3 audit events (transaction, data access, config change), downloads and verifies one
- **03-scientific-data**: research data archival with `--std "PROV-O"` and `--duration 720` (30-day retention) — uploads experiment metadata + CSV sensor data
- **05-encrypted-data**: pre-encryption workflow with `--enc "AES-256-GCM"` — encrypts locally, uploads, downloads, verifies encrypted payload, decrypts
- **06-market-memory**: canonical JSON hashing with `--std "MARKET-MEMORY-V1"` — prediction→observation linking via Swarm references, content hash verification
- Each example includes `README.md`, `demo.sh`, `run_demo.py`, and sample data files (22 new files total)
- 76 new unit tests + 8 integration tests added to `tests/test_examples.py`
- Updated `examples/README.md` with all 4 new entries

## Test plan

- [x] All 100 example tests pass (`pytest tests/test_examples.py` — 100 passed, 10 integration skipped)
- [x] Full test suite passes (464 passed, 10 skipped)
- [x] All 4 Python demos verified end-to-end against dev gateway with x402
- [x] Basic demo also re-verified against dev gateway

Closes #21, closes #22, closes #24, closes #25