### PR TITLE
Rename SWARM_X402_PRIVATE_KEY to X402_PRIVATE_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ DEFAULT_POSTAGE_AMOUNT=1000000000
 # X402_ENABLED=true
 
 # Your wallet private key (keep secret!)
-# SWARM_X402_PRIVATE_KEY=0x...
+# X402_PRIVATE_KEY=0x...
 
 # Network: "base-sepolia" (testnet, default) or "base" (mainnet)
 # X402_NETWORK=base-sepolia

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,7 +317,7 @@ Uses python-dotenv for environment configuration:
 
 **x402 Payment Configuration**:
 - `X402_ENABLED`: Enable x402 payment support (default: false)
-- `SWARM_X402_PRIVATE_KEY`: Wallet private key for signing payments
+- `X402_PRIVATE_KEY`: Wallet private key for signing payments
 - `X402_NETWORK`: `base-sepolia` (testnet) or `base` (mainnet)
 - `X402_AUTO_PAY`: Enable auto-pay without prompts (default: false)
 - `X402_MAX_AUTO_PAY_USD`: Maximum auto-pay amount per request (default: 1.00)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ x402 enables pay-per-request payments using USDC on Base chain. When the gateway
 pip install -e .[x402]
 
 # Configure wallet (testnet)
-export SWARM_X402_PRIVATE_KEY=0x...  # Your wallet private key
+export X402_PRIVATE_KEY=0x...  # Your wallet private key
 export X402_ENABLED=true
 export X402_NETWORK=base-sepolia     # Testnet (default)
 
@@ -145,7 +145,7 @@ swarm-prov-upload x402 info
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
 | `X402_ENABLED` | Enable x402 payments | `false` |
-| `SWARM_X402_PRIVATE_KEY` | Wallet private key (keep secret!) | - |
+| `X402_PRIVATE_KEY` | Wallet private key (keep secret!) | - |
 | `X402_NETWORK` | `base-sepolia` (testnet) or `base` (mainnet) | `base-sepolia` |
 | `X402_AUTO_PAY` | Auto-pay without prompts | `false` |
 | `X402_MAX_AUTO_PAY_USD` | Maximum auto-pay amount per request | `1.00` |
@@ -164,7 +164,7 @@ swarm-prov-upload x402 info
 
 1. **Get testnet ETH** (for gas): https://www.alchemy.com/faucets/base-sepolia
 2. **Get testnet USDC**: https://faucet.circle.com/
-3. **Configure wallet**: Set `SWARM_X402_PRIVATE_KEY` with your wallet's private key
+3. **Configure wallet**: Set `X402_PRIVATE_KEY` with your wallet's private key
 
 See [docs/x402-setup.md](docs/x402-setup.md) for detailed setup instructions.
 
@@ -794,7 +794,7 @@ See [examples/README.md](examples/README.md) for the full guide.
 │  │ └─────────────────────────────┘ │  │                                     │  │
 │  │                                 │  │ x402 Configuration:                 │  │
 │  │ x402 Payment Models:            │  │ • X402_ENABLED                      │  │
-│  │ • X402PaymentOption             │  │ • SWARM_X402_PRIVATE_KEY            │  │
+│  │ • X402PaymentOption             │  │ • X402_PRIVATE_KEY            │  │
 │  │ • X402PaymentRequirements       │  │ • X402_NETWORK                      │  │
 │  │ • X402PaymentPayload            │  │ • X402_AUTO_PAY                     │  │
 │  │                                 │  │ • X402_MAX_AUTO_PAY_USD             │  │

--- a/docs/x402-setup.md
+++ b/docs/x402-setup.md
@@ -140,7 +140,7 @@ Add to your `.env` file:
 X402_ENABLED=true
 
 # Your wallet private key (KEEP SECRET!)
-SWARM_X402_PRIVATE_KEY=0x...your_private_key_here...
+X402_PRIVATE_KEY=0x...your_private_key_here...
 
 # Network: base-sepolia (testnet) or base (mainnet)
 X402_NETWORK=base-sepolia
@@ -217,9 +217,9 @@ pip install -e .[x402]
 
 ### "No private key configured"
 
-Set the `SWARM_X402_PRIVATE_KEY` environment variable:
+Set the `X402_PRIVATE_KEY` environment variable:
 ```bash
-export SWARM_X402_PRIVATE_KEY=0x...
+export X402_PRIVATE_KEY=0x...
 ```
 
 ### "Insufficient USDC balance"

--- a/swarm_provenance_uploader/cli.py
+++ b/swarm_provenance_uploader/cli.py
@@ -1432,7 +1432,7 @@ def x402_info():
     typer.echo("   - Export private key (starts with 0x)")
 
     typer.echo("\n2. Set environment variable:")
-    typer.echo("   export SWARM_X402_PRIVATE_KEY=0x...")
+    typer.echo("   export X402_PRIVATE_KEY=0x...")
 
     typer.echo("\n3. Get testnet funds (for testing):")
     typer.echo("   - ETH (gas): https://www.alchemy.com/faucets/base-sepolia")
@@ -2349,7 +2349,7 @@ def main(
     Use --backend local for direct Bee node communication.
 
     For pay-per-request mode, use --x402 to enable x402 payments.
-    Requires SWARM_X402_PRIVATE_KEY environment variable.
+    Requires X402_PRIVATE_KEY environment variable.
     """
     if backend:
         if backend not in ("gateway", "local"):

--- a/swarm_provenance_uploader/config.py
+++ b/swarm_provenance_uploader/config.py
@@ -41,7 +41,7 @@ X402_ENABLED = os.getenv("X402_ENABLED", "false").lower() == "true"
 
 # Environment variable name that contains the private key
 # The actual private key should be in this env var, not in config
-X402_PRIVATE_KEY_ENV = os.getenv("X402_PRIVATE_KEY_ENV", "SWARM_X402_PRIVATE_KEY")
+X402_PRIVATE_KEY_ENV = os.getenv("X402_PRIVATE_KEY_ENV", "X402_PRIVATE_KEY")
 
 # Network: "base-sepolia" (testnet, default) or "base" (mainnet)
 X402_NETWORK = os.getenv("X402_NETWORK", "base-sepolia")

--- a/swarm_provenance_uploader/core/x402_client.py
+++ b/swarm_provenance_uploader/core/x402_client.py
@@ -255,7 +255,7 @@ class X402Client:
         self._private_key = private_key or os.getenv("X402_PRIVATE_KEY") or os.getenv("SWARM_X402_PRIVATE_KEY")
         if not self._private_key:
             raise X402ConfigurationError(
-                "x402 private key not configured. Set X402_PRIVATE_KEY or SWARM_X402_PRIVATE_KEY environment variable."
+                "x402 private key not configured. Set X402_PRIVATE_KEY environment variable."
             )
 
         # Validate and derive address

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -730,7 +730,7 @@ class TestX402InfoCommand:
 
         assert result.exit_code == 0
         assert "x402 Payment Setup Guide" in result.stdout
-        assert "SWARM_X402_PRIVATE_KEY" in result.stdout
+        assert "X402_PRIVATE_KEY" in result.stdout
         assert "faucet" in result.stdout.lower()
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,7 +6,7 @@ These tests require actual running services:
 
 For x402 tests:
 - Base Sepolia wallet with USDC
-- SWARM_X402_PRIVATE_KEY environment variable set
+- X402_PRIVATE_KEY environment variable set
 
 For blockchain tests:
 - Local Hardhat node at http://localhost:8545 with DataProvenance deployed
@@ -91,7 +91,7 @@ skip_if_no_gateway = pytest.mark.skipif(
 
 def is_x402_configured():
     """Check if x402 wallet is configured."""
-    private_key = os.getenv("SWARM_X402_PRIVATE_KEY")
+    private_key = os.getenv("X402_PRIVATE_KEY")
     return private_key is not None and private_key.startswith("0x")
 
 
@@ -107,7 +107,7 @@ def are_x402_deps_installed():
 
 skip_if_no_x402 = pytest.mark.skipif(
     not is_x402_configured() or not are_x402_deps_installed(),
-    reason="x402 not configured (SWARM_X402_PRIVATE_KEY not set or deps missing)"
+    reason="x402 not configured (X402_PRIVATE_KEY not set or deps missing)"
 )
 
 
@@ -220,7 +220,7 @@ class TestX402Integration:
     """Integration tests for x402 payment functionality.
 
     These tests require:
-    - SWARM_X402_PRIVATE_KEY environment variable set
+    - X402_PRIVATE_KEY environment variable set
     - x402 dependencies installed (pip install -e .[x402])
     - Base Sepolia wallet with USDC (from faucet.circle.com)
     """
@@ -420,7 +420,7 @@ class TestX402Integration:
         """Test GatewayClient initializes with x402 enabled."""
         from swarm_provenance_uploader.core.gateway_client import GatewayClient
 
-        private_key = os.getenv("SWARM_X402_PRIVATE_KEY")
+        private_key = os.getenv("X402_PRIVATE_KEY")
 
         client = GatewayClient(
             base_url=gateway_url,
@@ -476,7 +476,7 @@ class TestX402PaymentFlow:
         from swarm_provenance_uploader.core.x402_client import X402Client
         from swarm_provenance_uploader.exceptions import PaymentTransactionFailedError
 
-        private_key = os.getenv("SWARM_X402_PRIVATE_KEY")
+        private_key = os.getenv("X402_PRIVATE_KEY")
 
         # Get balance before payment
         x402_client = X402Client(private_key=private_key, network="base-sepolia")

--- a/tests/test_x402_client.py
+++ b/tests/test_x402_client.py
@@ -44,7 +44,7 @@ SAMPLE_402_RESPONSE = {
 @pytest.fixture
 def mock_eth_deps():
     """Mock eth-account and web3 dependencies."""
-    with patch.dict(os.environ, {"SWARM_X402_PRIVATE_KEY": DUMMY_PRIVATE_KEY}):
+    with patch.dict(os.environ, {"X402_PRIVATE_KEY": DUMMY_PRIVATE_KEY}):
         # Mock eth_account
         mock_account = MagicMock()
         mock_account.address = DUMMY_ADDRESS
@@ -263,7 +263,7 @@ class TestX402ClientBalance:
 
     def test_balance_insufficient(self):
         """Tests balance check when insufficient."""
-        with patch.dict(os.environ, {"SWARM_X402_PRIVATE_KEY": DUMMY_PRIVATE_KEY}):
+        with patch.dict(os.environ, {"X402_PRIVATE_KEY": DUMMY_PRIVATE_KEY}):
             # Mock eth_account
             mock_account = MagicMock()
             mock_account.address = DUMMY_ADDRESS
@@ -367,7 +367,7 @@ class TestX402ClientCreatePaymentHeader:
 
     def test_create_payment_header_insufficient_balance(self):
         """Tests payment header creation fails with insufficient balance."""
-        with patch.dict(os.environ, {"SWARM_X402_PRIVATE_KEY": DUMMY_PRIVATE_KEY}):
+        with patch.dict(os.environ, {"X402_PRIVATE_KEY": DUMMY_PRIVATE_KEY}):
             # Mock eth_account
             mock_account = MagicMock()
             mock_account.address = DUMMY_ADDRESS
@@ -500,7 +500,7 @@ class TestX402ClientPrivateKeyFormat:
         """Tests that private key without 0x prefix is handled."""
         key_without_prefix = "a" * 64  # No 0x prefix
 
-        with patch.dict(os.environ, {"SWARM_X402_PRIVATE_KEY": key_without_prefix}):
+        with patch.dict(os.environ, {"X402_PRIVATE_KEY": key_without_prefix}):
             mock_account = MagicMock()
             mock_account.address = DUMMY_ADDRESS
 
@@ -535,7 +535,7 @@ class TestX402ClientErrorHandling:
 
     def test_rpc_connection_failure(self):
         """Tests handling of RPC connection failures during balance check."""
-        with patch.dict(os.environ, {"SWARM_X402_PRIVATE_KEY": DUMMY_PRIVATE_KEY}):
+        with patch.dict(os.environ, {"X402_PRIVATE_KEY": DUMMY_PRIVATE_KEY}):
             mock_account = MagicMock()
             mock_account.address = DUMMY_ADDRESS
 


### PR DESCRIPTION
## Summary

- Rename `SWARM_X402_PRIVATE_KEY` env var to `X402_PRIVATE_KEY` — not Swarm-specific, may be used by other services
- Backwards-compatible fallback preserved in `x402_client.py`
- Add `PROVENANCE_WALLET_KEY` to `.env.local` for on-chain anchoring (same wallet for testing, separate keys in production)

## Test plan

- [x] 535 unit tests pass
- [x] Base Sepolia blockchain tests pass (3/4, anchor tx confirmed on-chain)