### PR TITLE
Fix gateway integration test pollution from .env.local

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -46,8 +46,13 @@ def local_bee_url():
 
 @pytest.fixture
 def gateway_url():
-    """Gateway URL from environment or default."""
-    return os.getenv("PROVENANCE_GATEWAY_URL", "https://provenance-gateway.datafund.io")
+    """Gateway URL for integration tests.
+
+    Uses INTEGRATION_GATEWAY_URL if set, otherwise defaults to production.
+    This is intentionally separate from PROVENANCE_GATEWAY_URL (used by the
+    app and often overridden in .env.local for local development).
+    """
+    return os.getenv("INTEGRATION_GATEWAY_URL", "https://provenance-gateway.datafund.io")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- The `gateway_url` fixture in integration tests was reading `PROVENANCE_GATEWAY_URL`, which `.env.local` overrides to `localhost:8000` for local development
- This caused 4 gateway tests to fail when run with `.env.local` sourced (needed for x402/chain tests)
- Changed fixture to use `INTEGRATION_GATEWAY_URL` env var, defaulting to production gateway, keeping integration tests independent of app config

## Test plan

- [x] All 35 integration tests pass (gateway, x402, Hardhat, Base Sepolia)
- [x] 545 unit tests pass
- [x] Gateway tests pass both with and without `.env.local` sourced