### PR TITLE
V2 contract parity: chain module rewrite for DataProvenance v2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,8 @@ swarm-prov-upload chain transform <orig> <new> --description "..."           # R
 swarm-prov-upload chain transform <orig> <new> --restrict-original           # Transform + restrict original
 swarm-prov-upload chain protect <orig> <new> --description "..."             # Composite: transform + restrict
 swarm-prov-upload chain protect <orig> <new> --anchor-new                    # Protect with auto-anchor
+swarm-prov-upload chain merge <h1> <h2> [<h3>...] <new> --description "..."  # N-to-1 merge transformation
+swarm-prov-upload chain merge <h1> <h2> <new> --type "dataset"               # Merge with custom data type
 
 # Collection/manifest upload (directory as Swarm manifest, gateway only)
 swarm-prov-upload upload-collection /path/to/directory                       # Upload directory
@@ -204,10 +206,12 @@ The application follows a modular architecture with clear separation of concerns
    - `file_utils.py`: File I/O and encoding utilities
    - `metadata_builder.py`: Metadata construction
 3. **Chain Subpackage** (`chain/`): Low-level blockchain components
-   - `provider.py`: Web3 connection management with chain presets
+   - `provider.py`: Web3 connection management with chain presets and RPC failover
    - `wallet.py`: Private key handling and transaction signing
-   - `contract.py`: DataProvenance contract wrapper with build_*_tx pattern
-   - `abi/DataProvenance.json`: Embedded contract ABI
+   - `contract.py`: DataProvenance contract wrapper with build_*_tx pattern, v2 auto-detection
+   - `event_cache.py`: Thread-safe singleton cache for transformation event logs (v1 fallback)
+   - `exceptions.py`: Standalone chain exception hierarchy
+   - `abi/DataProvenance.json`: Embedded v2 contract ABI
 4. **Data Models** (`models.py`): Pydantic v2 schemas for metadata and API responses
 5. **Exceptions** (`exceptions.py`): Custom exception hierarchy for unified error handling
 6. **Configuration** (`config.py`): Environment-based configuration management
@@ -235,10 +239,13 @@ The application follows a modular architecture with clear separation of concerns
 **ChainClient** (`core/chain_client.py`):
 - High-level facade for on-chain provenance operations
 - Wraps ChainProvider + ChainWallet + DataProvenanceContract
-- Write methods: `anchor()`, `anchor_for()`, `batch_anchor()`, `transform()`, `access()`, `batch_access()`, `set_status()`, `transfer_ownership()`, `set_delegate()`
+- Write methods: `anchor()`, `anchor_for()`, `batch_anchor()`, `transform()`, `merge_transform()`, `access()`, `batch_access()`, `set_status()`, `transfer_ownership()`, `set_delegate()`
 - Read methods: `get()`, `verify()`, `get_provenance_chain()`, `balance()`, `health_check()`
 - Lazy-loads web3 and eth-account via `blockchain` optional dependency group
-- Targets DataProvenance contract on Base Sepolia (`0x9a3c6F47B69211F05891CCb7aD33596290b9fE64`)
+- Targets DataProvenance v2 contract on Base Sepolia (`0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a`)
+- V2 auto-detection: state-based traversal on v2 contracts, event cache fallback on v1
+- Duplicate transformation pre-checks to avoid wasting gas
+- RPC failover support via `rpc_fallbacks` parameter
 
 ### Key Components
 
@@ -269,6 +276,7 @@ The application follows a modular architecture with clear separation of concerns
 - `ChainProvenanceRecord`: Full on-chain provenance record
 - `AnchorResult`: Transaction result from anchoring a hash
 - `TransformResult`: Transaction result from recording a transformation
+- `MergeTransformResult`: Transaction result from N-to-1 merge transformation
 - `AccessResult`: Transaction result from recording data access
 - `ChainWalletInfo`: Wallet balance and chain configuration info
 - `SignedDocumentResponse`: Response from upload with sign=notary
@@ -332,6 +340,7 @@ Uses python-dotenv for environment configuration:
 - `CHAIN_ENABLED`: Enable on-chain anchoring (default: false)
 - `CHAIN_NAME`: `base-sepolia` (testnet, default) or `base` (mainnet)
 - `CHAIN_RPC_URL`: Custom RPC URL (optional, overrides preset)
+- `CHAIN_RPC_URLS`: Comma-separated fallback RPC URLs (optional, overrides preset fallbacks)
 - `CHAIN_CONTRACT`: Custom contract address (optional, overrides preset)
 - `CHAIN_EXPLORER_URL`: Custom block explorer URL (optional, overrides preset)
 - `CHAIN_GAS_LIMIT`: Explicit gas limit (optional, skips RPC estimation when set)

--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ swarm-prov-upload chain access <swarm_hash>
 swarm-prov-upload chain transform <original_hash> <new_hash> --description "Anonymized PII"
 swarm-prov-upload chain transform <orig> <new> --restrict-original  # restrict original after transform
 
+# Record an N-to-1 merge transformation (all sources must be anchored, v2 contract)
+swarm-prov-upload chain merge <hash1> <hash2> [<hash3>...] <new_hash> --description "Merged datasets"
+
 # Get full provenance record
 swarm-prov-upload chain get <swarm_hash>
 swarm-prov-upload chain get <swarm_hash> --json
@@ -291,6 +294,7 @@ swarm-prov-upload chain get <hash> --follow --json        # JSON output
 | `CHAIN_CONTRACT` | Custom contract address (optional) | Uses preset |
 | `CHAIN_EXPLORER_URL` | Custom block explorer URL (optional) | Uses preset |
 | `CHAIN_GAS_LIMIT` | Explicit gas limit (optional, skips RPC estimation) | Auto-estimated |
+| `CHAIN_RPC_URLS` | Comma-separated fallback RPC URLs (optional) | Uses preset fallbacks |
 
 ### Testnet Setup
 
@@ -315,6 +319,7 @@ print(f"TX: {result.explorer_url}")
 - `anchor_for(swarm_hash, owner, data_type)` - Register on behalf of another owner
 - `batch_anchor(swarm_hashes, data_types)` - Batch register multiple hashes
 - `transform(original_hash, new_hash, description)` - Record data transformation
+- `merge_transform(source_hashes, new_hash, description)` - Record N-to-1 merge (v2 contract)
 - `access(swarm_hash)` - Record data access
 - `batch_access(swarm_hashes)` - Batch record access
 - `set_status(swarm_hash, status)` - Change data status (ACTIVE/RESTRICTED/DELETED)
@@ -840,8 +845,9 @@ See [examples/README.md](examples/README.md) for the full guide with walkthrough
 │  │ • ChainProvenanceRecord         │  │ Chain Configuration:                │  │
 │  │ • AnchorResult                  │  │ • CHAIN_ENABLED                     │  │
 │  │ • TransformResult               │  │ • CHAIN_NAME                        │  │
-│  │ • AccessResult                  │  │ • PROVENANCE_WALLET_KEY             │  │
-│  │ • ChainWalletInfo               │  │ • CHAIN_RPC_URL                     │  │
+│  │ • MergeTransformResult          │  │ • PROVENANCE_WALLET_KEY             │  │
+│  │ • AccessResult                  │  │ • CHAIN_RPC_URL                     │  │
+│  │ • ChainWalletInfo               │  │ • CHAIN_RPC_URLS (fallbacks)        │  │
 │  │                                 │  │ • CHAIN_EXPLORER_URL                │  │
 │  └─────────────────────────────────┘  └─────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────────────────────────┘

--- a/README.md
+++ b/README.md
@@ -1037,6 +1037,8 @@ swarm_provenance_uploader/
 │   │   ├── provider.py          # Web3 connection management
 │   │   ├── wallet.py            # Transaction signing
 │   │   ├── contract.py          # DataProvenance contract wrapper
+│   │   ├── event_cache.py       # Transformation event cache (v1 fallback)
+│   │   ├── exceptions.py        # Chain-specific exception hierarchy
 │   │   └── abi/
 │   │       └── DataProvenance.json  # Contract ABI
 │   └── core/

--- a/docs/chain-setup.md
+++ b/docs/chain-setup.md
@@ -208,6 +208,40 @@ swarm-prov-upload chain anchor <original_hash>
 swarm-prov-upload chain transform <original_hash> <new_hash> --description "Anonymized PII fields"
 ```
 
+### Merge multiple datasets
+
+When you combine multiple data sources into one, record it as a merge transformation:
+
+```bash
+# All source hashes must be anchored first
+swarm-prov-upload chain anchor <hash_a>
+swarm-prov-upload chain anchor <hash_b>
+
+# Record the merge (2-50 sources supported)
+swarm-prov-upload chain merge <hash_a> <hash_b> <merged_hash> --description "Combined datasets"
+
+# With a custom data type for the merged result
+swarm-prov-upload chain merge <hash_a> <hash_b> <merged_hash> --type "combined-dataset" -d "Merged A+B"
+```
+
+### Walk the provenance chain
+
+Trace data lineage back through transformations:
+
+```bash
+# Get full provenance record
+swarm-prov-upload chain get <hash>
+
+# Walk the full transformation chain (follows links to root)
+swarm-prov-upload chain get <hash> --follow
+
+# Limit traversal depth
+swarm-prov-upload chain get <hash> --follow --depth 2
+
+# JSON output for scripting
+swarm-prov-upload chain get <hash> --follow --json
+```
+
 ### Record data access
 
 Log that data was accessed (idempotent — safe to record multiple times):

--- a/docs/chain-setup.md
+++ b/docs/chain-setup.md
@@ -144,7 +144,7 @@ swarm-prov-upload chain balance
 #   Address:  0x742d...fE00
 #   Balance:  0.01 ETH
 #   Chain:    base-sepolia
-#   Contract: 0x9a3c...fE64
+#   Contract: 0xD4a7...f80a
 #
 # Get testnet ETH: https://www.alchemy.com/faucets/base-sepolia
 ```
@@ -164,7 +164,7 @@ swarm-prov-upload chain anchor <swarm_hash>
 #   Tx:      0xbb...
 #   Block:   12345679
 #   Gas:     95000
-#   Explorer: https://sepolia.basescan.org/tx/0xbb...
+#   Explorer: https://base-sepolia.blockscout.com/tx/0xbb...
 ```
 
 ### Verify the anchor
@@ -294,13 +294,16 @@ Or add it to your `.env` file.
 
 ### "Cannot connect to chain"
 
-Check your RPC endpoint. The default Base Sepolia RPC (`https://sepolia.base.org`) is public and rate-limited. For production, use a dedicated RPC provider:
+Check your RPC endpoint. The default Base Sepolia RPC (`https://sepolia.base.org`) is public and rate-limited. The CLI automatically tries fallback RPCs (`base-sepolia-rpc.publicnode.com`, `base-sepolia.drpc.org`) if the primary fails. For production, use a dedicated RPC provider:
 - [Alchemy](https://www.alchemy.com/)
 - [Infura](https://www.infura.io/)
 - [QuickNode](https://www.quicknode.com/)
 
 ```bash
 export CHAIN_RPC_URL=https://base-sepolia.g.alchemy.com/v2/YOUR_KEY
+
+# Or set multiple fallback URLs (comma-separated)
+export CHAIN_RPC_URLS=https://fallback1.io,https://fallback2.io
 ```
 
 ### "Transaction reverted"
@@ -341,8 +344,10 @@ export CHAIN_CONTRACT=0x...your_contract_address...
 |----------|-------|
 | Chain ID | 84532 |
 | RPC URL | https://sepolia.base.org |
-| Block Explorer | https://sepolia.basescan.org |
-| DataProvenance Contract | `0x9a3c6F47B69211F05891CCb7aD33596290b9fE64` |
+| Fallback RPCs | base-sepolia-rpc.publicnode.com, base-sepolia.drpc.org |
+| Block Explorer | https://base-sepolia.blockscout.com |
+| DataProvenance Contract | `0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a` |
+| Deploy Block | 39,075,766 |
 
 ### Base (Mainnet)
 
@@ -350,11 +355,22 @@ export CHAIN_CONTRACT=0x...your_contract_address...
 |----------|-------|
 | Chain ID | 8453 |
 | RPC URL | https://mainnet.base.org |
+| Fallback RPCs | base-rpc.publicnode.com, base.drpc.org |
 | Block Explorer | https://basescan.org |
 | DataProvenance Contract | Not yet deployed |
+
+### Localhost (Development)
+
+| Property | Value |
+|----------|-------|
+| Chain ID | 31337 |
+| RPC URL | http://127.0.0.1:8545 |
+| DataProvenance Contract | `0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9` |
+
+Use `--chain localhost` for local Hardhat development.
 
 ## Additional Resources
 
 - [Base Documentation](https://docs.base.org)
-- [Etherscan Base Sepolia](https://sepolia.basescan.org)
+- [Base Sepolia Block Explorer](https://base-sepolia.blockscout.com)
 - [Alchemy Base Sepolia Faucet](https://www.alchemy.com/faucets/base-sepolia)

--- a/docs/chain-workflows.md
+++ b/docs/chain-workflows.md
@@ -25,6 +25,7 @@ How the chain subsystem is structured internally:
 │  Write ops:  anchor(), transform(), access(), set_status(),         │
 │              transfer_ownership(), set_delegate()                   │
 │              batch_anchor(), batch_access(), batch_set_status()     │
+│              merge_transform()  (N-to-1 merge, v2+)                │
 │  Read ops:   get(), verify(), balance(), health_check(),            │
 │              get_provenance_chain()                                  │
 └────────┬──────────────────┬──────────────────┬──────────────────────┘
@@ -37,14 +38,25 @@ How the chain subsystem is structured internally:
 │  Web3 conn mgmt │ │  Private key │ │  ABI wrapper               │
 │  Chain presets  │ │  TX signing  │ │  build_*_tx() methods      │
 │  Explorer URLs  │ │  Balance     │ │  get_data_record()         │
-│  Health checks  │ │              │ │  Hash normalization        │
-│  Chain ID auto- │ │              │ │                            │
+│  Health checks  │ │              │ │  V2 state traversal        │
+│  RPC failover   │ │              │ │  Hash normalization        │
+│  Chain ID auto- │ │              │ │  Chunked event queries     │
 │  detection      │ │              │ │  ABI: abi/DataProvenance   │
 └────────┬────────┘ └──────┬───────┘ └────────────┬───────────────┘
          │                 │                       │
          └─────────────────┴───────────────────────┘
                            │
                            ▼
+              ┌───────────────────────┐
+              │  TransformationEvent  │
+              │  Cache (event_cache)  │
+              │                       │
+              │  Thread-safe singleton│
+              │  Forward/reverse maps │
+              │  Incremental scanning │
+              └───────────┬───────────┘
+                          │
+                          ▼
                    ┌───────────────┐
                    │   Base Chain  │
                    │  (via RPC)    │
@@ -431,6 +443,7 @@ alice_client.set_delegate("0xBob...", authorized=False)
 | `set_status` | Write | ~45,000 | Status change |
 | `transfer_ownership` | Write | ~50,000 | Owner change |
 | `set_delegate` | Write | ~45,000 | Authorize/revoke |
+| `merge_transform` | Write | ~120k + ~30k/source | N-to-1 merge (2-50 sources, v2+) |
 | `batch_anchor` | Write | ~95k + ~60k/item | Up to 50 per batch |
 | `batch_access` | Write | ~65k + ~45k/item | Up to 100 per batch |
 | `verify` | Read | Free | No gas |

--- a/docs/chain-workflows.md
+++ b/docs/chain-workflows.md
@@ -10,8 +10,8 @@ How the chain subsystem is structured internally:
 ┌─────────────────────────────────────────────────────────────────────┐
 │                          CLI Layer (cli.py)                         │
 │                                                                     │
-│  chain balance | anchor | verify | get | access | transform         │
-│  chain status | transfer | delegate | protect                       │
+│  chain balance | anchor | verify | get | access | transform | merge  │
+│  chain status | transfer | delegate | protect                        │
 │  Global flags: --chain, --chain-rpc                                 │
 └──────────────────────────┬──────────────────────────────────────────┘
                            │
@@ -507,6 +507,77 @@ swarm-prov-upload chain status aaa... --set restricted
 
 # Alternatively, steps 3+4 in one command:
 swarm-prov-upload chain transform aaa... bbb... --restrict-original -d "Removed PII"
+```
+
+## Merge Transformation (N-to-1)
+
+Combine multiple data sources into one. Unlike `transform` (1-to-1), `merge` links 2-50 source hashes to a single new hash.
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                       Merge Transformation Flow                             │
+└──────────────────────────────────────────────────────────────────────────────┘
+
+  On-chain records:
+
+  ┌─────────────────────┐
+  │  Dataset A           │
+  │  hash: aaa...        │──────────┐
+  │  type: survey-data   │          │
+  │  status: ACTIVE      │          │  merge_transform()
+  └─────────────────────┘          │  "Combined survey regions"
+                                    │
+  ┌─────────────────────┐          │       ┌─────────────────────┐
+  │  Dataset B           │          ├──────>│  Merged Dataset      │
+  │  hash: bbb...        │──────────┘       │  hash: mmm...        │
+  │  type: survey-data   │                  │  type: merged-dataset │
+  │  status: ACTIVE      │                  │  owner: 0x742d...    │
+  └─────────────────────┘                  │  status: ACTIVE      │
+                                            └─────────────────────┘
+
+  Key differences from transform:
+  - Multiple sources (2-50) instead of one
+  - New hash is auto-registered by the contract
+  - All source hashes must already be anchored
+```
+
+**CLI commands:**
+```bash
+# 1. Anchor both source datasets
+swarm-prov-upload chain anchor aaa... --type survey-data
+swarm-prov-upload chain anchor bbb... --type survey-data
+
+# 2. Record the merge
+swarm-prov-upload chain merge aaa... bbb... mmm... --description "Combined survey regions"
+
+# 3. Merge with custom type
+swarm-prov-upload chain merge aaa... bbb... mmm... --type "combined-dataset" -d "Merged"
+
+# 4. Verify the merged hash is registered
+swarm-prov-upload chain verify mmm...
+
+# 5. View the merged record
+swarm-prov-upload chain get mmm... --json
+```
+
+**Python API:**
+```python
+from swarm_provenance_uploader.core.chain_client import ChainClient
+
+client = ChainClient()
+
+# Anchor sources
+client.anchor("aaa...", data_type="survey-data")
+client.anchor("bbb...", data_type="survey-data")
+
+# Record merge
+result = client.merge_transform(
+    source_hashes=["aaa...", "bbb..."],
+    new_hash="mmm...",
+    description="Combined survey regions",
+    new_data_type="combined-dataset",
+)
+print(f"TX: {result.tx_hash}, Gas: {result.gas_used}")
 ```
 
 ## Depth-Limited Chain Traversal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swarm-provenance-uploader"
-version = "0.8.3"
+version = "0.9.0"
 description = "A CLI toolkit for wrapping data and uploading to Swarm."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/swarm_provenance_uploader/__init__.py
+++ b/swarm_provenance_uploader/__init__.py
@@ -3,7 +3,7 @@
 import subprocess
 from pathlib import Path
 
-__version_base__ = "0.8.3"
+__version_base__ = "0.9.0"
 
 
 def _get_git_hash() -> str:

--- a/swarm_provenance_uploader/chain/__init__.py
+++ b/swarm_provenance_uploader/chain/__init__.py
@@ -4,9 +4,36 @@ try:
     from .provider import ChainProvider
     from .contract import DataProvenanceContract
     from .wallet import ChainWallet
+    from .event_cache import TransformationEventCache, get_cache, clear_registry
+    from .exceptions import (
+        ChainError,
+        ChainConfigurationError,
+        ChainConnectionError,
+        ChainTransactionError,
+        ChainValidationError,
+        DataNotRegisteredError,
+        DataAlreadyRegisteredError,
+        TransformationAlreadyExistsError,
+    )
 
     BLOCKCHAIN_AVAILABLE = True
-    __all__ = ["ChainProvider", "DataProvenanceContract", "ChainWallet", "BLOCKCHAIN_AVAILABLE"]
+    __all__ = [
+        "ChainProvider",
+        "DataProvenanceContract",
+        "ChainWallet",
+        "TransformationEventCache",
+        "get_cache",
+        "clear_registry",
+        "ChainError",
+        "ChainConfigurationError",
+        "ChainConnectionError",
+        "ChainTransactionError",
+        "ChainValidationError",
+        "DataNotRegisteredError",
+        "DataAlreadyRegisteredError",
+        "TransformationAlreadyExistsError",
+        "BLOCKCHAIN_AVAILABLE",
+    ]
 except ImportError:
     BLOCKCHAIN_AVAILABLE = False
     __all__ = ["BLOCKCHAIN_AVAILABLE"]

--- a/swarm_provenance_uploader/chain/abi/DataProvenance.json
+++ b/swarm_provenance_uploader/chain/abi/DataProvenance.json
@@ -29,6 +29,31 @@
       {
         "indexed": true,
         "internalType": "bytes32",
+        "name": "newDataHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "sourceDataHashes",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "transformation",
+        "type": "string"
+      }
+    ],
+    "name": "DataMerged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
         "name": "dataHash",
         "type": "bytes32"
       },
@@ -239,6 +264,19 @@
   },
   {
     "inputs": [],
+    "name": "MAX_MERGE_SOURCES",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "MAX_TRANSFORMATIONS",
     "outputs": [
       {
@@ -396,6 +434,25 @@
         "type": "bytes32"
       }
     ],
+    "name": "getChildHashes",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      }
+    ],
     "name": "getDataRecord",
     "outputs": [
       {
@@ -421,9 +478,21 @@
             "type": "string"
           },
           {
-            "internalType": "string[]",
-            "name": "transformations",
-            "type": "string[]"
+            "components": [
+              {
+                "internalType": "bytes32",
+                "name": "newDataHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "string",
+                "name": "description",
+                "type": "string"
+              }
+            ],
+            "internalType": "struct DataProvenance.TransformationLink[]",
+            "name": "transformationLinks",
+            "type": "tuple[]"
           },
           {
             "internalType": "address[]",
@@ -482,6 +551,56 @@
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getTransformationLinks",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "newDataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "string",
+            "name": "description",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct DataProvenance.TransformationLink[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getTransformationParents",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
       }
     ],
     "stateMutability": "view",
@@ -671,6 +790,34 @@
       }
     ],
     "name": "recordAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "_sourceDataHashes",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_newDataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "_transformation",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_newDataType",
+        "type": "string"
+      }
+    ],
+    "name": "recordMergeTransformation",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/swarm_provenance_uploader/chain/contract.py
+++ b/swarm_provenance_uploader/chain/contract.py
@@ -8,12 +8,14 @@ Requires optional dependencies: pip install swarm-provenance-uploader[blockchain
 """
 
 import json
+import logging
 from enum import IntEnum
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from ..exceptions import ChainConfigurationError, ChainValidationError
+from .exceptions import ChainConfigurationError, ChainValidationError
 
+logger = logging.getLogger(__name__)
 
 # --- Constants ---
 # Client-side validation limits (not enforced on-chain — Solidity strings are
@@ -25,6 +27,8 @@ MAX_TRANSFORMATION_LENGTH = 256
 # but larger batches risk exceeding the block gas limit.
 MAX_BATCH_REGISTER = 50
 MAX_BATCH_ACCESS = 100
+MIN_MERGE_SOURCES = 2
+MAX_MERGE_SOURCES = 50
 
 # Note: the contract also defines on-chain constants MAX_TRANSFORMATIONS (100)
 # and MAX_ACCESSORS readable via contract.functions.MAX_TRANSFORMATIONS().call().
@@ -462,15 +466,49 @@ class DataProvenanceContract:
         """
         Get the full on-chain record for a data hash.
 
+        The bundled ABI uses the v2 schema (``TransformationLink[]`` /
+        ``tuple[]``).  On v1 contracts where ``getDataRecord`` returns
+        ``string[]`` for transformations, the ABI decoder will fail; we
+        fall back to ``dataRecords()`` (scalar fields, no arrays).
+
         Args:
             data_hash: 64-char hex hash.
 
         Returns:
             Tuple of (dataHash, owner, timestamp, dataType,
                        transformations, accessors, status).
+
+            On v1 contracts, field 4 (transformations) is ``string[]``.
+            On v2 contracts, field 4 is ``TransformationLink[]``
+            (list of tuples ``(bytes32, string)``).
         """
         hash_bytes = _normalize_hash(data_hash)
-        return self._contract.functions.getDataRecord(hash_bytes).call()
+        try:
+            return self._contract.functions.getDataRecord(hash_bytes).call()
+        except (OverflowError, Exception) as e:
+            # V1 contracts return string[] for transformations but the ABI
+            # declares tuple[] (v2), causing a decode error.  Reconstruct
+            # the record from the scalar mapping.
+            if self.supports_transformation_links():
+                raise  # genuine error on v2 — re-raise
+            logger.debug("getDataRecord decode failed on v1, using fallback: %s", e)
+            return self._get_data_record_v1_fallback(hash_bytes)
+
+    def _get_data_record_v1_fallback(self, hash_bytes: bytes) -> Tuple:
+        """Reconstruct getDataRecord result for v1 contracts.
+
+        The v2 ABI expects ``TransformationLink[]`` tuples but v1
+        contracts return ``string[]``, causing a decode error.  Falls
+        back to ``dataRecords()`` (scalar fields only — no arrays).
+        Accessors and transformations are returned as empty lists; callers
+        can still get transformations from ``DataTransformed`` events.
+        """
+        # dataRecords returns: (dataHash, owner, timestamp, dataType, status)
+        basic = self._contract.functions.dataRecords(hash_bytes).call()
+        data_hash, owner, timestamp, data_type, status = basic
+
+        # Return the same 7-element tuple shape as getDataRecord
+        return (data_hash, owner, timestamp, data_type, [], [], status)
 
     def get_user_data_records(self, user: str) -> List[bytes]:
         """
@@ -555,6 +593,292 @@ class DataProvenanceContract:
             self._web3.to_checksum_address(owner),
             self._web3.to_checksum_address(delegate),
         ).call()
+
+    # --- V2 view methods (available on upgraded contracts only) ---
+
+    _supports_v2: Optional[bool] = None
+
+    def supports_transformation_links(self) -> bool:
+        """Check if the deployed contract supports v2 TransformationLink functions.
+
+        Performs a trial call on first invocation and caches the result.
+        Returns False for v1 contracts where the function reverts.
+        """
+        if self._supports_v2 is not None:
+            return self._supports_v2
+        try:
+            test_hash = b"\x00" * 32
+            self._contract.functions.getTransformationLinks(test_hash).call()
+            self._supports_v2 = True
+        except Exception:
+            self._supports_v2 = False
+        return self._supports_v2
+
+    def get_transformation_links(self, data_hash: str) -> List[Tuple[bytes, str]]:
+        """
+        Forward traversal via contract state (v2+).
+
+        Args:
+            data_hash: 64-char hex hash.
+
+        Returns:
+            List of (newDataHash_bytes, description) tuples.
+
+        Raises:
+            Exception: If the contract does not support this function.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        result = self._contract.functions.getTransformationLinks(hash_bytes).call()
+        return [(link[0], link[1]) for link in result]
+
+    def get_child_hashes(self, data_hash: str) -> List[bytes]:
+        """
+        Lightweight forward traversal: just child hashes (v2+).
+
+        Args:
+            data_hash: 64-char hex hash.
+
+        Returns:
+            List of newDataHash bytes.
+
+        Raises:
+            Exception: If the contract does not support this function.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        return self._contract.functions.getChildHashes(hash_bytes).call()
+
+    def get_transformation_parents(self, data_hash: str) -> List[bytes]:
+        """
+        Reverse traversal via contract state (v2+).
+
+        Args:
+            data_hash: 64-char hex hash.
+
+        Returns:
+            List of parent hash bytes.
+
+        Raises:
+            Exception: If the contract does not support this function.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        return self._contract.functions.getTransformationParents(hash_bytes).call()
+
+    # --- Merge transaction builder (v2+) ---
+
+    def build_record_merge_transformation_tx(
+        self,
+        source_hashes: List[str],
+        new_hash: str,
+        description: str,
+        new_data_type: str,
+        sender: str,
+    ) -> dict:
+        """
+        Build tx for N-to-1 merge transformation (v2+).
+
+        Args:
+            source_hashes: List of original data hashes (2-50 items).
+            new_hash: Hash of the merged data.
+            description: Transformation description (max 256 chars).
+            new_data_type: Data type for the merged result (max 64 chars).
+            sender: Address of the transaction sender.
+
+        Returns:
+            Unsigned transaction dict.
+
+        Raises:
+            ChainValidationError: If source count or formats are invalid.
+        """
+        if len(source_hashes) < MIN_MERGE_SOURCES:
+            raise ChainValidationError(
+                f"Merge requires at least {MIN_MERGE_SOURCES} sources, "
+                f"got {len(source_hashes)}"
+            )
+        if len(source_hashes) > MAX_MERGE_SOURCES:
+            raise ChainValidationError(
+                f"Merge source count {len(source_hashes)} exceeds maximum "
+                f"of {MAX_MERGE_SOURCES}"
+            )
+        source_bytes = [_normalize_hash(h) for h in source_hashes]
+        new_bytes = _normalize_hash(new_hash)
+        _validate_transformation(description)
+        _validate_data_type(new_data_type)
+        return self._contract.functions.recordMergeTransformation(
+            source_bytes,
+            new_bytes,
+            description,
+            new_data_type,
+        ).build_transaction({
+            "from": self._web3.to_checksum_address(sender),
+        })
+
+    # --- Event queries ---
+
+    # Public RPCs enforce per-request block range limits (Base Sepolia
+    # allows ~10k blocks).  We chunk large lookbacks into windows of
+    # this size so that the default 50k lookback works reliably.
+    _EVENT_CHUNK_SIZE = 10_000
+
+    def _get_logs_chunked(self, event, argument_filters, from_block, to_block):
+        """
+        Query event logs in chunks to avoid RPC payload limits.
+
+        Splits the range [from_block, to_block] into windows of
+        ``_EVENT_CHUNK_SIZE`` and concatenates results.  On 413/payload
+        errors the failing chunk is halved once before giving up.
+
+        ``argument_filters`` may be ``None`` to fetch all events of the
+        given type (unfiltered scan).
+        """
+        all_events = []
+        start = from_block
+
+        # Build kwargs — omit argument_filters when None so web3 uses
+        # its default (no topic filtering beyond the event signature).
+        def _get(fb, tb):
+            kw = {"from_block": fb, "to_block": tb}
+            if argument_filters:
+                kw["argument_filters"] = argument_filters
+            return event.get_logs(**kw)
+
+        while start <= to_block:
+            end = min(start + self._EVENT_CHUNK_SIZE - 1, to_block)
+            try:
+                all_events.extend(_get(start, end))
+            except Exception as e:
+                err_str = str(e).lower()
+                if "413" in err_str or "payload" in err_str or "too large" in err_str:
+                    # Halve the chunk and retry once
+                    mid = (start + end) // 2
+                    if mid == start:
+                        raise  # Can't split further
+                    try:
+                        all_events.extend(_get(start, mid))
+                        all_events.extend(_get(mid + 1, end))
+                    except Exception:
+                        raise  # Give up on this chunk
+                else:
+                    raise
+            start = end + 1
+        return all_events
+
+    def get_transformations_from(
+        self,
+        data_hash: str,
+        lookback_blocks: int = 50_000,
+    ) -> List[Tuple[bytes, bytes, str]]:
+        """
+        Query DataTransformed events where data_hash is the original.
+
+        Args:
+            data_hash: 64-char hex hash.
+            lookback_blocks: How many blocks to scan backwards from latest.
+
+        Returns:
+            List of (originalDataHash, newDataHash, description) tuples.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        latest = self._web3.eth.block_number
+        from_block = max(0, latest - lookback_blocks)
+        events = self._get_logs_chunked(
+            self._contract.events.DataTransformed,
+            {"originalDataHash": hash_bytes},
+            from_block,
+            latest,
+        )
+        return [
+            (evt.args.originalDataHash, evt.args.newDataHash, evt.args.transformation)
+            for evt in events
+        ]
+
+    def get_transformations_to(
+        self,
+        data_hash: str,
+        lookback_blocks: int = 50_000,
+    ) -> List[Tuple[bytes, bytes, str]]:
+        """
+        Query DataTransformed events where data_hash is the new (reverse lookup).
+
+        Args:
+            data_hash: 64-char hex hash.
+            lookback_blocks: How many blocks to scan backwards from latest.
+
+        Returns:
+            List of (originalDataHash, newDataHash, description) tuples.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        latest = self._web3.eth.block_number
+        from_block = max(0, latest - lookback_blocks)
+        events = self._get_logs_chunked(
+            self._contract.events.DataTransformed,
+            {"newDataHash": hash_bytes},
+            from_block,
+            latest,
+        )
+        return [
+            (evt.args.originalDataHash, evt.args.newDataHash, evt.args.transformation)
+            for evt in events
+        ]
+
+    def get_all_transformations(
+        self,
+        from_block: int = 0,
+        to_block: int = None,
+    ) -> List[Tuple[bytes, bytes, str]]:
+        """
+        Query ALL DataTransformed events in a block range (no hash filter).
+
+        Used by the event cache to build an in-memory index of all
+        transformations, enabling BFS traversal without per-node
+        event queries.
+
+        Args:
+            from_block: Start of the scan range (e.g. contract deploy block).
+            to_block: End of the scan range. Defaults to latest block.
+
+        Returns:
+            List of (originalDataHash, newDataHash, description) tuples.
+        """
+        latest = to_block if to_block is not None else self._web3.eth.block_number
+        events = self._get_logs_chunked(
+            self._contract.events.DataTransformed,
+            None,
+            from_block,
+            latest,
+        )
+        return [
+            (evt.args.originalDataHash, evt.args.newDataHash, evt.args.transformation)
+            for evt in events
+        ]
+
+    def get_all_merge_events(
+        self,
+        from_block: int = 0,
+        to_block: int = None,
+    ) -> list:
+        """
+        Query ALL DataMerged events in a block range (v2+ contracts).
+
+        Args:
+            from_block: Start of the scan range.
+            to_block: End of the scan range. Defaults to latest block.
+
+        Returns:
+            List of event objects with args: newDataHash, sourceDataHashes,
+            transformation, newDataType.  Returns empty list if the
+            contract does not emit DataMerged events.
+        """
+        latest = to_block if to_block is not None else self._web3.eth.block_number
+        try:
+            return self._get_logs_chunked(
+                self._contract.events.DataMerged,
+                None,
+                from_block,
+                latest,
+            )
+        except Exception:
+            # Contract may not have DataMerged event (v1)
+            return []
 
     # --- Gas estimation ---
 

--- a/swarm_provenance_uploader/chain/event_cache.py
+++ b/swarm_provenance_uploader/chain/event_cache.py
@@ -1,0 +1,150 @@
+"""
+In-memory cache for DataTransformed and DataMerged event logs.
+
+On v1 contracts, the DataProvenance contract stores transformation
+descriptions (string[]) but NOT the linked hashes in state — newDataHash
+is only in event logs.  This forces get_provenance_chain to scan the full
+contract history on every call (~1.4M blocks on Base Sepolia, ~20s).
+
+This module provides a singleton cache per (chain, contract_address) that
+does a full scan on first call and incremental scans on subsequent calls,
+reducing repeat queries to <1s.  Also scans DataMerged events (v2+) and
+adds forward/reverse entries for each merge source.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton registry keyed by (chain, contract_address_lower)
+_registry: dict[tuple[str, str], TransformationEventCache] = {}
+_registry_lock = threading.Lock()
+
+
+class TransformationEventCache:
+    """Thread-safe in-memory cache of DataTransformed events.
+
+    Builds forward and reverse lookup maps from event logs.
+    First call does a full scan from deploy_block; subsequent calls
+    scan only new blocks since the last scan.
+    """
+
+    def __init__(self):
+        self._forward: dict[str, list[tuple[str, str]]] = {}
+        self._reverse: dict[str, list[tuple[str, str]]] = {}
+        self._last_scanned_block: int | None = None
+        self._lock = threading.Lock()
+
+    def get_maps(
+        self,
+        contract,
+        deploy_block: int,
+        current_block: int,
+    ) -> tuple[dict, dict]:
+        """Return (forward, reverse) transformation maps.
+
+        Args:
+            contract: DataProvenanceContract instance with get_all_transformations().
+            deploy_block: Contract deploy block (start of first scan).
+            current_block: Latest block number (end of scan range).
+
+        Returns:
+            Tuple of (forward, reverse) dicts:
+              forward: original_hex -> [(new_hex, description), ...]
+              reverse: new_hex -> [(original_hex, description), ...]
+
+        Raises:
+            Exception: Propagated from contract.get_all_transformations()
+                on scan failure. Caller should catch and fall back to
+                per-node event queries.
+        """
+        with self._lock:
+            if self._last_scanned_block is None:
+                from_block = deploy_block
+            else:
+                from_block = self._last_scanned_block + 1
+
+            if from_block > current_block:
+                return self._forward, self._reverse
+
+            events = contract.get_all_transformations(
+                from_block=from_block,
+                to_block=current_block,
+            )
+
+            for orig_bytes, new_bytes, desc in events:
+                orig_hex = (
+                    orig_bytes.hex()
+                    if isinstance(orig_bytes, bytes)
+                    else str(orig_bytes)
+                )
+                new_hex = (
+                    new_bytes.hex() if isinstance(new_bytes, bytes) else str(new_bytes)
+                )
+                self._forward.setdefault(orig_hex, []).append((new_hex, desc))
+                self._reverse.setdefault(new_hex, []).append((orig_hex, desc))
+
+            # Also scan DataMerged events (v2+ contracts).
+            # For each merge: each source -> new_hash (forward),
+            # new_hash -> each source (reverse).
+            try:
+                merge_events = contract.get_all_merge_events(
+                    from_block=from_block,
+                    to_block=current_block,
+                )
+                for evt in merge_events:
+                    new_bytes = evt.args.newDataHash
+                    new_hex = (
+                        new_bytes.hex()
+                        if isinstance(new_bytes, bytes)
+                        else str(new_bytes)
+                    )
+                    desc = evt.args.transformation
+                    for src_bytes in evt.args.sourceDataHashes:
+                        src_hex = (
+                            src_bytes.hex()
+                            if isinstance(src_bytes, bytes)
+                            else str(src_bytes)
+                        )
+                        self._forward.setdefault(src_hex, []).append((new_hex, desc))
+                        self._reverse.setdefault(new_hex, []).append((src_hex, desc))
+            except Exception as e:
+                logger.debug("DataMerged event scan skipped: %s", e)
+
+            self._last_scanned_block = current_block
+            logger.debug(
+                "Event cache updated: scanned blocks %d-%d, "
+                "%d forward entries, %d reverse entries",
+                from_block,
+                current_block,
+                len(self._forward),
+                len(self._reverse),
+            )
+
+            return self._forward, self._reverse
+
+
+def get_cache(chain: str, contract_address: str) -> TransformationEventCache:
+    """Get or create the singleton cache for a (chain, contract) pair.
+
+    Args:
+        chain: Chain name (e.g. 'base-sepolia').
+        contract_address: Contract address (case-insensitive).
+
+    Returns:
+        TransformationEventCache instance (shared across callers).
+    """
+    key = (chain, contract_address.lower())
+    with _registry_lock:
+        if key not in _registry:
+            _registry[key] = TransformationEventCache()
+        return _registry[key]
+
+
+def clear_registry():
+    """Clear all cached instances. For testing only."""
+    with _registry_lock:
+        _registry.clear()

--- a/swarm_provenance_uploader/chain/exceptions.py
+++ b/swarm_provenance_uploader/chain/exceptions.py
@@ -1,0 +1,81 @@
+"""Custom exceptions for blockchain-related operations.
+
+Standalone exception hierarchy for the chain module. These inherit from
+the main ProvenanceError base to keep a unified exception tree while
+allowing the chain module to be self-contained.
+"""
+
+from ..exceptions import ProvenanceError
+
+
+class ChainError(ProvenanceError):
+    """Base exception for blockchain-related errors."""
+    pass
+
+
+class ChainConfigurationError(ChainError):
+    """Missing dependencies, invalid config, or missing wallet key."""
+    pass
+
+
+class ChainConnectionError(ChainError):
+    """Failed to connect to RPC endpoint."""
+
+    def __init__(self, message: str, rpc_url: str = None):
+        super().__init__(message)
+        self.rpc_url = rpc_url
+
+
+class ChainTransactionError(ChainError):
+    """Transaction reverted, ran out of gas, or otherwise failed."""
+
+    def __init__(self, message: str, tx_hash: str = None):
+        super().__init__(message)
+        self.tx_hash = tx_hash
+
+
+class ChainValidationError(ChainError):
+    """Input validation failed (hash format, string lengths, batch limits)."""
+    pass
+
+
+class DataNotRegisteredError(ChainError):
+    """Data hash not found on-chain."""
+
+    def __init__(self, message: str, data_hash: str = None):
+        super().__init__(message)
+        self.data_hash = data_hash
+
+
+class DataAlreadyRegisteredError(ChainError):
+    """Data hash is already registered on-chain."""
+
+    def __init__(
+        self,
+        message: str,
+        data_hash: str = None,
+        owner: str = None,
+        timestamp: int = None,
+        data_type: str = None,
+    ):
+        super().__init__(message)
+        self.data_hash = data_hash
+        self.owner = owner
+        self.timestamp = timestamp
+        self.data_type = data_type
+
+
+class TransformationAlreadyExistsError(ChainError):
+    """Transformation (original -> new) pair is already recorded on-chain."""
+
+    def __init__(
+        self,
+        message: str,
+        original_hash: str = None,
+        new_hash: str = None,
+        existing_description: str = None,
+    ):
+        super().__init__(message)
+        self.original_hash = original_hash
+        self.new_hash = new_hash
+        self.existing_description = existing_description

--- a/swarm_provenance_uploader/chain/provider.py
+++ b/swarm_provenance_uploader/chain/provider.py
@@ -7,10 +7,12 @@ for interacting with the DataProvenance smart contract.
 Requires optional dependencies: pip install swarm-provenance-uploader[blockchain]
 """
 
-from typing import Optional
+import logging
+from typing import List, Optional
 
-from ..exceptions import ChainConfigurationError, ChainConnectionError
+from .exceptions import ChainConfigurationError, ChainConnectionError
 
+logger = logging.getLogger(__name__)
 
 # Lazy web3 import
 _Web3 = None
@@ -36,14 +38,32 @@ CHAIN_PRESETS = {
     "base-sepolia": {
         "chain_id": 84532,
         "rpc_url": "https://sepolia.base.org",
-        "explorer_url": "https://sepolia.basescan.org",
-        "contract_address": "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64",
+        "explorer_url": "https://base-sepolia.blockscout.com",
+        "contract_address": "0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a",
+        "deploy_block": 39_075_766,
+        "rpc_fallbacks": [
+            "https://base-sepolia-rpc.publicnode.com",
+            "https://base-sepolia.drpc.org",
+        ],
     },
     "base": {
         "chain_id": 8453,
         "rpc_url": "https://mainnet.base.org",
         "explorer_url": "https://basescan.org",
         "contract_address": None,  # Not yet deployed
+        "deploy_block": None,
+        "rpc_fallbacks": [
+            "https://base-rpc.publicnode.com",
+            "https://base.drpc.org",
+        ],
+    },
+    "localhost": {
+        "chain_id": 31337,
+        "rpc_url": "http://127.0.0.1:8545",
+        "explorer_url": None,
+        "contract_address": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
+        "deploy_block": 0,
+        "rpc_fallbacks": [],
     },
 }
 
@@ -63,15 +83,20 @@ class ChainProvider:
         rpc_url: Optional[str] = None,
         contract_address: Optional[str] = None,
         explorer_url: Optional[str] = None,
+        rpc_fallbacks: Optional[List[str]] = None,
+        request_timeout: int = 30,
     ):
         """
         Initialize the chain provider.
 
         Args:
-            chain: Chain name ('base-sepolia' or 'base').
+            chain: Chain name ('base-sepolia', 'base', or 'localhost').
             rpc_url: Custom RPC URL. If None, uses preset for chain.
             contract_address: Custom contract address. If None, uses preset.
             explorer_url: Custom block explorer URL. If None, uses preset.
+            rpc_fallbacks: Fallback RPC URLs tried in order on failure.
+                If None and no custom rpc_url, uses preset fallbacks.
+            request_timeout: HTTP request timeout in seconds (default 30).
 
         Raises:
             ChainConfigurationError: If chain is unsupported or web3 not installed.
@@ -88,7 +113,20 @@ class ChainProvider:
         self.rpc_url = rpc_url or preset["rpc_url"]
         self.explorer_url = explorer_url or preset["explorer_url"]
         self.contract_address = contract_address or preset["contract_address"]
+        self.deploy_block = preset.get("deploy_block")
         self._custom_rpc = rpc_url is not None
+        self._request_timeout = request_timeout
+
+        # Build ordered list of RPC URLs to try
+        if rpc_fallbacks is not None:
+            # Explicit fallbacks provided
+            self._rpc_urls = [self.rpc_url] + list(rpc_fallbacks)
+        elif not self._custom_rpc:
+            # No custom RPC — use preset fallbacks
+            self._rpc_urls = [self.rpc_url] + preset.get("rpc_fallbacks", [])
+        else:
+            # Custom RPC with no explicit fallbacks — primary only
+            self._rpc_urls = [self.rpc_url]
 
         if not self.contract_address:
             raise ChainConfigurationError(
@@ -97,7 +135,12 @@ class ChainProvider:
             )
 
         # Initialize Web3 connection
-        self._web3 = Web3(Web3.HTTPProvider(self.rpc_url))
+        self._web3 = Web3(
+            Web3.HTTPProvider(
+                self.rpc_url,
+                request_kwargs={"timeout": self._request_timeout},
+            )
+        )
 
         # When a custom RPC is provided, auto-detect chain ID from the node
         # (e.g. local Hardhat uses chain ID 31337, not the preset chain ID)
@@ -114,6 +157,42 @@ class ChainProvider:
         """Get the Web3 instance."""
         return self._web3
 
+    def _try_fallback(self) -> bool:
+        """
+        Try fallback RPC URLs when the current one fails.
+
+        Iterates through remaining URLs in ``_rpc_urls`` (skipping the
+        current ``rpc_url``), attempts ``is_connected()``, and switches
+        ``_web3`` and ``rpc_url`` on the first success.
+
+        Returns:
+            True if a working fallback was found and switched to.
+        """
+        Web3 = _import_web3()
+
+        for url in self._rpc_urls:
+            if url == self.rpc_url:
+                continue
+            try:
+                candidate = Web3(
+                    Web3.HTTPProvider(
+                        url,
+                        request_kwargs={"timeout": self._request_timeout},
+                    )
+                )
+                if candidate.is_connected():
+                    logger.info(
+                        "RPC fallback: switched from %s to %s",
+                        self.rpc_url,
+                        url,
+                    )
+                    self._web3 = candidate
+                    self.rpc_url = url
+                    return True
+            except Exception:
+                continue
+        return False
+
     def health_check(self) -> bool:
         """
         Check if the RPC endpoint is reachable and responding.
@@ -122,7 +201,7 @@ class ChainProvider:
             True if connected and chain ID matches.
 
         Raises:
-            ChainConnectionError: If connection fails.
+            ChainConnectionError: If connection fails (after trying fallbacks).
         """
         try:
             if not self._web3.is_connected():
@@ -138,8 +217,12 @@ class ChainProvider:
                 )
             return True
         except ChainConnectionError:
+            if self._try_fallback():
+                return self.health_check()
             raise
         except Exception as e:
+            if self._try_fallback():
+                return self.health_check()
             raise ChainConnectionError(
                 f"RPC health check failed: {e}",
                 rpc_url=self.rpc_url,
@@ -153,17 +236,19 @@ class ChainProvider:
             The current block number.
 
         Raises:
-            ChainConnectionError: If RPC call fails.
+            ChainConnectionError: If RPC call fails (after trying fallbacks).
         """
         try:
             return self._web3.eth.block_number
         except Exception as e:
+            if self._try_fallback():
+                return self.get_block_number()
             raise ChainConnectionError(
                 f"Failed to get block number: {e}",
                 rpc_url=self.rpc_url,
             ) from e
 
-    def get_explorer_tx_url(self, tx_hash: str) -> str:
+    def get_explorer_tx_url(self, tx_hash: str) -> Optional[str]:
         """
         Get block explorer URL for a transaction.
 
@@ -171,13 +256,15 @@ class ChainProvider:
             tx_hash: Transaction hash (with or without 0x prefix).
 
         Returns:
-            Full block explorer URL for the transaction.
+            Full block explorer URL for the transaction, or None if no explorer configured.
         """
+        if not self.explorer_url:
+            return None
         if not tx_hash.startswith("0x"):
             tx_hash = "0x" + tx_hash
         return f"{self.explorer_url}/tx/{tx_hash}"
 
-    def get_explorer_address_url(self, address: str) -> str:
+    def get_explorer_address_url(self, address: str) -> Optional[str]:
         """
         Get block explorer URL for an address.
 
@@ -185,8 +272,10 @@ class ChainProvider:
             address: Ethereum address (with or without 0x prefix).
 
         Returns:
-            Full block explorer URL for the address.
+            Full block explorer URL for the address, or None if no explorer configured.
         """
+        if not self.explorer_url:
+            return None
         if not address.startswith("0x"):
             address = "0x" + address
         return f"{self.explorer_url}/address/{address}"

--- a/swarm_provenance_uploader/chain/wallet.py
+++ b/swarm_provenance_uploader/chain/wallet.py
@@ -10,7 +10,7 @@ Requires optional dependencies: pip install swarm-provenance-uploader[blockchain
 import os
 from typing import Optional
 
-from ..exceptions import ChainConfigurationError
+from .exceptions import ChainConfigurationError
 
 
 # Lazy eth-account import

--- a/swarm_provenance_uploader/cli.py
+++ b/swarm_provenance_uploader/cli.py
@@ -1,5 +1,5 @@
 import typer
-from typing import Optional
+from typing import List, Optional
 from typing_extensions import Annotated
 from pathlib import Path
 import sys
@@ -2345,6 +2345,89 @@ def chain_protect(
     typer.echo(f"  New:       {new_hash}")
     if description:
         typer.echo(f"  Desc:      {description}")
+
+
+@chain_app.command("merge")
+def chain_merge(
+    hashes: Annotated[List[str], typer.Argument(help="Source hashes followed by the new (merged) hash. Minimum 3 values (2 sources + 1 new).")],
+    description: Annotated[str, typer.Option("--description", "-d", help="Description of the merge.")] = "",
+    data_type: Annotated[str, typer.Option("--type", "-t", help="Data type for the merged result.")] = "merged",
+    gas: Annotated[Optional[int], typer.Option("--gas", help="Explicit gas limit (skips estimation).")] = None,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable verbose output.")] = False,
+    output_json: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
+):
+    """
+    Record an N-to-1 merge transformation on-chain.
+
+    Provide 2+ source hashes followed by the new (merged) hash as positional arguments.
+    All source hashes must already be anchored on-chain.
+
+    Example: swarm-prov-upload chain merge <hash1> <hash2> <new_hash> -d "Merged datasets"
+    """
+    if len(hashes) < 3:
+        typer.secho(
+            "ERROR: Need at least 3 hashes: 2+ source hashes and 1 new hash.",
+            fg=typer.colors.RED, err=True,
+        )
+        typer.echo("Usage: swarm-prov-upload chain merge <source1> <source2> [<source3>...] <new_hash>")
+        raise typer.Exit(code=1)
+
+    source_hashes = hashes[:-1]
+    new_hash = hashes[-1]
+
+    if gas is not None:
+        _chain_config["gas_limit"] = gas
+    try:
+        client = _get_chain_client(verbose=verbose)
+        result = client.merge_transform(
+            source_hashes=source_hashes,
+            new_hash=new_hash,
+            description=description,
+            new_data_type=data_type,
+            verbose=verbose,
+        )
+    except typer.Exit:
+        raise
+    except exceptions.DataNotRegisteredError as e:
+        typer.secho(f"ERROR: Source hash is not registered on-chain.", fg=typer.colors.RED, err=True)
+        if e.data_hash:
+            typer.echo(f"  Hash: {e.data_hash}")
+        typer.echo(f"  Anchor source hashes first: swarm-prov-upload chain anchor <hash>")
+        raise typer.Exit(code=1)
+    except exceptions.ChainValidationError as e:
+        typer.secho(f"ERROR: Validation failed: {e}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1)
+    except exceptions.ChainTransactionError as e:
+        typer.secho(f"ERROR: Transaction failed: {e}", fg=typer.colors.RED, err=True)
+        if e.tx_hash:
+            typer.echo(f"  Transaction: {e.tx_hash}")
+        raise typer.Exit(code=1)
+    except exceptions.ChainConnectionError as e:
+        typer.secho(f"ERROR: Cannot connect to chain: {e}", fg=typer.colors.RED, err=True)
+        if e.rpc_url:
+            typer.echo(f"  RPC URL: {e.rpc_url}")
+        raise typer.Exit(code=1)
+    except exceptions.ChainError as e:
+        typer.secho(f"ERROR: {e}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1)
+
+    if output_json:
+        typer.echo(json.dumps(result.model_dump(), indent=2))
+        return
+
+    typer.secho(f"\nMerge transformation recorded!", fg=typer.colors.GREEN, bold=True)
+    typer.echo(f"  Sources: {len(source_hashes)}")
+    for i, sh in enumerate(source_hashes, 1):
+        typer.echo(f"    {i}. {sh}")
+    typer.echo(f"  New:     {new_hash}")
+    if description:
+        typer.echo(f"  Desc:    {description}")
+    typer.echo(f"  Type:    {data_type}")
+    typer.echo(f"  Tx:      {result.tx_hash}")
+    typer.echo(f"  Block:   {result.block_number}")
+    typer.echo(f"  Gas:     {result.gas_used}")
+    if result.explorer_url:
+        typer.echo(f"  Explorer: {result.explorer_url}")
 
 
 @app.callback()

--- a/swarm_provenance_uploader/core/chain_client.py
+++ b/swarm_provenance_uploader/core/chain_client.py
@@ -8,17 +8,15 @@ gas estimation, signing, broadcasting, and receipt parsing.
 Requires optional dependencies: pip install swarm-provenance-uploader[blockchain]
 """
 
-import os
+import logging
 from typing import List, Optional
 
 from ..chain.contract import DataStatus
-from ..exceptions import (
-    ChainConfigurationError,
-    ChainConnectionError,
+from ..chain.exceptions import (
     ChainTransactionError,
-    ChainValidationError,
     DataAlreadyRegisteredError,
     DataNotRegisteredError,
+    TransformationAlreadyExistsError,
 )
 from ..models import (
     AccessResult,
@@ -27,8 +25,11 @@ from ..models import (
     ChainTransformation,
     ChainWalletInfo,
     DataStatusEnum,
+    MergeTransformResult,
     TransformResult,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ChainClient:
@@ -49,12 +50,13 @@ class ChainClient:
         gas_limit_multiplier: float = 1.2,
         explorer_url: Optional[str] = None,
         gas_limit: Optional[int] = None,
+        rpc_fallbacks: Optional[List[str]] = None,
     ):
         """
         Initialize the chain client.
 
         Args:
-            chain: Chain name ('base-sepolia' or 'base').
+            chain: Chain name ('base-sepolia', 'base', or 'localhost').
             rpc_url: Custom RPC URL. If None, uses preset.
             contract_address: Custom contract address. If None, uses preset.
             private_key: Wallet private key. If None, reads from env var.
@@ -62,6 +64,7 @@ class ChainClient:
             gas_limit_multiplier: Safety multiplier for gas estimates (default 1.2).
             explorer_url: Custom block explorer URL. If None, uses preset.
             gas_limit: Explicit gas limit. If set, skips estimation and multiplier.
+            rpc_fallbacks: Fallback RPC URLs tried in order on failure.
 
         Raises:
             ChainConfigurationError: If dependencies missing or config invalid.
@@ -75,6 +78,7 @@ class ChainClient:
             rpc_url=rpc_url,
             contract_address=contract_address,
             explorer_url=explorer_url,
+            rpc_fallbacks=rpc_fallbacks,
         )
         self._wallet = ChainWallet(
             private_key=private_key,
@@ -128,18 +132,20 @@ class ChainClient:
             # Set gas limit: explicit value or estimate with multiplier
             if self._gas_limit is not None:
                 tx["gas"] = self._gas_limit
-                if verbose:
-                    print(f"DEBUG: Using explicit gas limit: {self._gas_limit}")
+                logger.debug("Using explicit gas limit: %d", self._gas_limit)
             else:
                 estimated_gas = web3.eth.estimate_gas(tx)
                 tx["gas"] = int(estimated_gas * self._gas_limit_multiplier)
-                if verbose:
-                    print(f"DEBUG: Estimated gas: {estimated_gas}, limit: {tx['gas']}")
+                logger.debug("Estimated gas: %d, limit: %d", estimated_gas, tx["gas"])
+
+            if verbose:
+                print(f"DEBUG: Gas limit: {tx['gas']}")
 
             # Sign and send
             raw_tx = self._wallet.sign_transaction(tx)
             tx_hash = web3.eth.send_raw_transaction(raw_tx)
 
+            logger.debug("Transaction sent: %s", tx_hash.hex())
             if verbose:
                 print(f"DEBUG: Transaction sent: {tx_hash.hex()}")
 
@@ -148,13 +154,17 @@ class ChainClient:
 
             if receipt["status"] != 1:
                 raise ChainTransactionError(
-                    f"Transaction reverted (status=0)",
+                    "Transaction reverted (status=0)",
                     tx_hash=tx_hash.hex(),
                 )
 
+            logger.debug(
+                "Transaction confirmed in block %d, gas used: %d",
+                receipt["blockNumber"],
+                receipt["gasUsed"],
+            )
             if verbose:
-                print(f"DEBUG: Transaction confirmed in block {receipt['blockNumber']}")
-                print(f"DEBUG: Gas used: {receipt['gasUsed']}")
+                print(f"DEBUG: Confirmed in block {receipt['blockNumber']}, gas: {receipt['gasUsed']}")
 
             return receipt
 
@@ -195,10 +205,7 @@ class ChainClient:
         Returns:
             AnchorResult with transaction details.
         """
-        if verbose:
-            print(f"--- DEBUG: Anchor ---")
-            print(f"Hash: {swarm_hash}")
-            print(f"Type: {data_type}")
+        logger.debug("Anchor: hash=%s type=%s", swarm_hash, data_type)
 
         # Pre-check: avoid wasting gas on already-registered hashes
         try:
@@ -218,7 +225,24 @@ class ChainClient:
             data_type=data_type,
             sender=self._wallet.address,
         )
-        receipt = self._send_transaction(tx, verbose=verbose)
+        try:
+            receipt = self._send_transaction(tx, verbose=verbose)
+        except ChainTransactionError as e:
+            # Detect "already registered" revert that the pre-check missed
+            # (can happen when public RPC serves stale reads)
+            if "already registered" in str(e).lower():
+                try:
+                    record = self.get(swarm_hash, verbose=verbose)
+                    raise DataAlreadyRegisteredError(
+                        f"Data hash {swarm_hash} is already registered on-chain",
+                        data_hash=swarm_hash,
+                        owner=record.owner,
+                        timestamp=record.timestamp,
+                        data_type=record.data_type,
+                    ) from e
+                except DataNotRegisteredError:
+                    pass  # Still not visible — re-raise original
+            raise
 
         return AnchorResult(
             tx_hash=receipt["transactionHash"].hex(),
@@ -251,10 +275,7 @@ class ChainClient:
         Returns:
             AnchorResult with transaction details.
         """
-        if verbose:
-            print(f"--- DEBUG: Anchor For ---")
-            print(f"Hash: {swarm_hash}")
-            print(f"Owner: {owner}")
+        logger.debug("Anchor for: hash=%s owner=%s", swarm_hash, owner)
 
         # Pre-check: avoid wasting gas on already-registered hashes
         try:
@@ -304,9 +325,7 @@ class ChainClient:
         Returns:
             AnchorResult for the batch transaction (swarm_hash is first hash).
         """
-        if verbose:
-            print(f"--- DEBUG: Batch Anchor ---")
-            print(f"Count: {len(swarm_hashes)}")
+        logger.debug("Batch anchor: count=%d", len(swarm_hashes))
 
         tx = self._contract.build_batch_register_data_tx(
             data_hashes=swarm_hashes,
@@ -344,11 +363,60 @@ class ChainClient:
         Returns:
             TransformResult with transaction details.
         """
-        if verbose:
-            print(f"--- DEBUG: Transform ---")
-            print(f"Original: {original_hash}")
-            print(f"New: {new_hash}")
-            print(f"Description: {description}")
+        logger.debug(
+            "Transform: original=%s new=%s desc=%s",
+            original_hash,
+            new_hash,
+            description,
+        )
+
+        # Pre-check: avoid wasting gas on duplicate transformations.
+        # Prefer state read on v2 contracts, fall back to event cache.
+        if self._contract.supports_transformation_links():
+            try:
+                links = self._contract.get_transformation_links(original_hash)
+                for existing_new, existing_desc in links:
+                    existing_hex = (
+                        existing_new.hex()
+                        if isinstance(existing_new, bytes)
+                        else str(existing_new)
+                    )
+                    if existing_hex == new_hash:
+                        raise TransformationAlreadyExistsError(
+                            f"Transformation {original_hash[:16]}... -> {new_hash[:16]}... already exists",
+                            original_hash=original_hash,
+                            new_hash=new_hash,
+                            existing_description=existing_desc,
+                        )
+            except TransformationAlreadyExistsError:
+                raise
+            except Exception as e:
+                logger.warning("State-based duplicate check failed: %s", e)
+        else:
+            deploy_block = self._provider.deploy_block
+            if deploy_block is not None:
+                try:
+                    from ..chain.event_cache import get_cache
+
+                    cache = get_cache(
+                        self._provider.chain, self._provider.contract_address
+                    )
+                    current_block = self._provider.web3.eth.block_number
+                    forward, _ = cache.get_maps(
+                        self._contract, deploy_block, current_block
+                    )
+                    for existing_new, existing_desc in forward.get(original_hash, []):
+                        if existing_new == new_hash:
+                            raise TransformationAlreadyExistsError(
+                                f"Transformation {original_hash[:16]}... -> {new_hash[:16]}... already exists",
+                                original_hash=original_hash,
+                                new_hash=new_hash,
+                                existing_description=existing_desc,
+                            )
+                except TransformationAlreadyExistsError:
+                    raise
+                except Exception as e:
+                    logger.warning("Duplicate check failed, proceeding: %s", e)
 
         tx = self._contract.build_record_transformation_tx(
             original_hash=original_hash,
@@ -383,9 +451,7 @@ class ChainClient:
         Returns:
             AccessResult with transaction details.
         """
-        if verbose:
-            print(f"--- DEBUG: Record Access ---")
-            print(f"Hash: {swarm_hash}")
+        logger.debug("Record access: hash=%s", swarm_hash)
 
         tx = self._contract.build_record_access_tx(
             data_hash=swarm_hash,
@@ -417,9 +483,7 @@ class ChainClient:
         Returns:
             AccessResult for the batch transaction.
         """
-        if verbose:
-            print(f"--- DEBUG: Batch Access ---")
-            print(f"Count: {len(swarm_hashes)}")
+        logger.debug("Batch access: count=%d", len(swarm_hashes))
 
         tx = self._contract.build_batch_record_access_tx(
             data_hashes=swarm_hashes,
@@ -453,10 +517,9 @@ class ChainClient:
         Returns:
             AnchorResult with transaction details.
         """
-        if verbose:
-            print(f"--- DEBUG: Set Status ---")
-            print(f"Hash: {swarm_hash}")
-            print(f"Status: {DataStatus(status).name}")
+        logger.debug(
+            "Set status: hash=%s status=%s", swarm_hash, DataStatus(status).name
+        )
 
         tx = self._contract.build_set_data_status_tx(
             data_hash=swarm_hash,
@@ -492,9 +555,7 @@ class ChainClient:
         Returns:
             AnchorResult with transaction details.
         """
-        if verbose:
-            print(f"--- DEBUG: Batch Set Status ---")
-            print(f"Count: {len(swarm_hashes)}")
+        logger.debug("Batch set status: count=%d", len(swarm_hashes))
 
         tx = self._contract.build_batch_set_data_status_tx(
             data_hashes=swarm_hashes,
@@ -530,10 +591,7 @@ class ChainClient:
         Returns:
             AnchorResult with transaction details.
         """
-        if verbose:
-            print(f"--- DEBUG: Transfer Ownership ---")
-            print(f"Hash: {swarm_hash}")
-            print(f"New owner: {new_owner}")
+        logger.debug("Transfer ownership: hash=%s new_owner=%s", swarm_hash, new_owner)
 
         tx = self._contract.build_transfer_ownership_tx(
             data_hash=swarm_hash,
@@ -569,10 +627,8 @@ class ChainClient:
         Returns:
             AnchorResult with transaction details.
         """
-        if verbose:
-            action = "Authorize" if authorized else "Revoke"
-            print(f"--- DEBUG: {action} Delegate ---")
-            print(f"Delegate: {delegate}")
+        action = "Authorize" if authorized else "Revoke"
+        logger.debug("%s delegate: %s", action, delegate)
 
         tx = self._contract.build_set_delegate_tx(
             delegate=delegate,
@@ -589,6 +645,57 @@ class ChainClient:
             swarm_hash="",
             data_type="",
             owner=self._wallet.address,
+        )
+
+    def merge_transform(
+        self,
+        source_hashes: List[str],
+        new_hash: str,
+        description: str,
+        new_data_type: str = "merged",
+        verbose: bool = False,
+    ) -> MergeTransformResult:
+        """
+        Record an N-to-1 merge transformation on-chain.
+
+        All source hashes must be registered. The new_hash is registered
+        automatically by the contract.
+
+        Args:
+            source_hashes: List of original data hashes (2-50).
+            new_hash: Hash of the merged data.
+            description: Transformation description (max 256 chars).
+            new_data_type: Data type for merged result (max 64 chars).
+            verbose: Enable debug output.
+
+        Returns:
+            MergeTransformResult with transaction details.
+        """
+        logger.debug(
+            "Merge transform: sources=%d new=%s desc=%s",
+            len(source_hashes),
+            new_hash,
+            description,
+        )
+
+        tx = self._contract.build_record_merge_transformation_tx(
+            source_hashes=source_hashes,
+            new_hash=new_hash,
+            description=description,
+            new_data_type=new_data_type,
+            sender=self._wallet.address,
+        )
+        receipt = self._send_transaction(tx, verbose=verbose)
+
+        return MergeTransformResult(
+            tx_hash=receipt["transactionHash"].hex(),
+            block_number=receipt["blockNumber"],
+            gas_used=receipt["gasUsed"],
+            explorer_url=self._receipt_to_explorer_url(receipt),
+            source_hashes=source_hashes,
+            new_hash=new_hash,
+            description=description,
+            new_data_type=new_data_type,
         )
 
     # --- Read operations ---
@@ -611,15 +718,21 @@ class ChainClient:
         Raises:
             DataNotRegisteredError: If hash is not registered on-chain.
         """
-        if verbose:
-            print(f"--- DEBUG: Get Record ---")
-            print(f"Hash: {swarm_hash}")
+        logger.debug("Get record: hash=%s", swarm_hash)
 
         record = self._contract.get_data_record(swarm_hash)
 
         # record is a tuple: (dataHash, owner, timestamp, dataType,
         #                      transformations, accessors, status)
-        data_hash_bytes, owner, timestamp, data_type, transformations, accessors, status = record
+        (
+            data_hash_bytes,
+            owner,
+            timestamp,
+            data_type,
+            transformations,
+            accessors,
+            status,
+        ) = record
 
         # Check if data is registered (owner is zero address if not)
         zero_address = "0x" + "0" * 40
@@ -629,12 +742,27 @@ class ChainClient:
                 data_hash=swarm_hash,
             )
 
-        # Parse transformations — contract returns string[] (description only)
+        # Parse transformations — v2 contracts return TransformationLink[]
+        # (list of (bytes32, string) tuples), v1 returns string[].
         chain_transformations = []
         for t in transformations:
-            chain_transformations.append(ChainTransformation(
-                description=str(t),
-            ))
+            if isinstance(t, (tuple, list)) and len(t) >= 2:
+                # V2 contract: TransformationLink(newDataHash, description)
+                new_hash = t[0].hex() if isinstance(t[0], bytes) else str(t[0])
+                chain_transformations.append(
+                    ChainTransformation(description=str(t[1]), new_data_hash=new_hash)
+                )
+            else:
+                # V1 contract: plain string description
+                chain_transformations.append(ChainTransformation(description=str(t)))
+
+        logger.debug(
+            "Record: owner=%s type=%s status=%s accessors=%d",
+            owner,
+            data_type,
+            DataStatus(status).name,
+            len(accessors),
+        )
 
         if verbose:
             print(f"DEBUG: Owner: {owner}")
@@ -643,7 +771,11 @@ class ChainClient:
             print(f"DEBUG: Accessors: {len(accessors)}")
 
         return ChainProvenanceRecord(
-            data_hash=data_hash_bytes.hex() if isinstance(data_hash_bytes, bytes) else str(data_hash_bytes),
+            data_hash=(
+                data_hash_bytes.hex()
+                if isinstance(data_hash_bytes, bytes)
+                else str(data_hash_bytes)
+            ),
             owner=owner,
             timestamp=timestamp,
             data_type=data_type,
@@ -683,11 +815,12 @@ class ChainClient:
         Returns:
             ChainWalletInfo with balance and chain details.
         """
-        if verbose:
-            print(f"--- DEBUG: Balance ---")
+        logger.debug("Balance check")
 
         balance_wei = self._wallet.get_balance(self._provider.web3)
         balance_eth = self._wallet.get_balance_eth(self._provider.web3)
+
+        logger.debug("Address: %s Balance: %s ETH", self._wallet.address, balance_eth)
 
         if verbose:
             print(f"DEBUG: Address: {self._wallet.address}")
@@ -714,12 +847,15 @@ class ChainClient:
         Raises:
             ChainConnectionError: If health check fails.
         """
-        if verbose:
-            print(f"--- DEBUG: Chain Health Check ---")
-            print(f"Chain: {self._provider.chain}")
-            print(f"RPC: {self._provider.rpc_url}")
+        logger.debug(
+            "Chain health check: chain=%s rpc=%s",
+            self._provider.chain,
+            self._provider.rpc_url,
+        )
 
         result = self._provider.health_check()
+
+        logger.debug("Connected, block: %d", self._provider.get_block_number())
 
         if verbose:
             block = self._provider.get_block_number()
@@ -736,12 +872,10 @@ class ChainClient:
         """
         Get the provenance chain for a data hash.
 
-        Retrieves the record for the given hash. If transformations have
-        new_data_hash links, follows them to build a lineage chain.
-
-        Note: The current contract returns transformation descriptions only
-        (no new_data_hash links), so the chain will typically contain just
-        the queried record. Supply hashes directly to follow known lineages.
+        On v2 contracts, uses state reads (``getTransformationLinks`` /
+        ``getTransformationParents``) for traversal — no event scanning.
+        On v1 contracts, falls back to the cached event scan path.
+        Falls back to per-node event scanning when the deploy block is unknown.
 
         Args:
             swarm_hash: Starting Swarm reference hash.
@@ -752,13 +886,41 @@ class ChainClient:
             List of ChainProvenanceRecord forming the provenance chain,
             starting with the given hash.
         """
-        if verbose:
-            print(f"--- DEBUG: Get Provenance Chain ---")
-            print(f"Starting hash: {swarm_hash}")
-            if max_depth is not None:
-                print(f"Max depth: {max_depth}")
+        logger.debug(
+            "Get provenance chain: hash=%s max_depth=%s", swarm_hash, max_depth
+        )
 
         effective_max = max_depth if max_depth is not None else 50
+
+        # Detect contract version — state reads are much faster than event scans
+        use_state_reads = False
+        try:
+            if self._contract.supports_transformation_links():
+                use_state_reads = True
+        except Exception:
+            pass
+
+        # Fall back to event cache for v1 contracts
+        from ..chain.event_cache import get_cache
+
+        forward = {}  # original_hex -> [(new_hex, desc)]
+        reverse = {}  # new_hex -> [(original_hex, desc)]
+        deploy_block = self._provider.deploy_block
+        use_local_index = False
+
+        if not use_state_reads and deploy_block is not None:
+            try:
+                cache = get_cache(self._provider.chain, self._provider.contract_address)
+                current_block = self._provider.web3.eth.block_number
+                forward, reverse = cache.get_maps(
+                    self._contract, deploy_block, current_block
+                )
+                use_local_index = True
+            except Exception as e:
+                logger.warning(
+                    "Full event scan failed, falling back to per-node queries: %s",
+                    e,
+                )
 
         chain = []
         visited = set()
@@ -769,23 +931,115 @@ class ChainClient:
             if current_hash in visited:
                 continue
             if current_depth > effective_max:
-                if verbose:
-                    print(f"DEBUG: Depth limit reached at {current_depth}")
+                logger.debug("Depth limit reached at %d", current_depth)
                 continue
             visited.add(current_hash)
 
             try:
                 record = self.get(current_hash, verbose=verbose)
-                chain.append(record)
-
-                # Follow transformation links if new_data_hash is available
-                for t in record.transformations:
-                    if t.new_data_hash and t.new_data_hash not in visited:
-                        to_visit.append((t.new_data_hash, current_depth + 1))
             except DataNotRegisteredError:
-                if verbose:
-                    print(f"DEBUG: Hash {current_hash} not registered, skipping")
+                logger.debug("Hash %s not registered, skipping", current_hash)
                 continue
+
+            if use_state_reads:
+                # V2 contract: state-based traversal
+                try:
+                    links = self._contract.get_transformation_links(current_hash)
+                    if links:
+                        record.transformations = [
+                            ChainTransformation(
+                                description=desc,
+                                new_data_hash=(
+                                    nh.hex() if isinstance(nh, bytes) else str(nh)
+                                ),
+                            )
+                            for nh, desc in links
+                        ]
+                        for nh, _ in links:
+                            nh_hex = nh.hex() if isinstance(nh, bytes) else str(nh)
+                            if nh_hex not in visited:
+                                to_visit.append((nh_hex, current_depth + 1))
+                except Exception as e:
+                    logger.warning(
+                        "State-based forward read failed for %s: %s",
+                        current_hash,
+                        e,
+                    )
+                # Reverse: parents via state
+                try:
+                    parents = self._contract.get_transformation_parents(current_hash)
+                    for p in parents:
+                        p_hex = p.hex() if isinstance(p, bytes) else str(p)
+                        if p_hex not in visited:
+                            to_visit.append((p_hex, current_depth + 1))
+                except Exception as e:
+                    logger.warning(
+                        "State-based reverse read failed for %s: %s",
+                        current_hash,
+                        e,
+                    )
+            elif use_local_index:
+                # V1 contract: use pre-built event cache index
+                fwd = forward.get(current_hash, [])
+                if fwd:
+                    record.transformations = [
+                        ChainTransformation(description=desc, new_data_hash=nh)
+                        for nh, desc in fwd
+                    ]
+                    for nh, _ in fwd:
+                        if nh not in visited:
+                            to_visit.append((nh, current_depth + 1))
+                # Reverse links (parents)
+                for orig_hex, _ in reverse.get(current_hash, []):
+                    if orig_hex not in visited:
+                        to_visit.append((orig_hex, current_depth + 1))
+            else:
+                # Per-node event scanning (fallback when deploy_block unknown)
+                try:
+                    events = self._contract.get_transformations_from(current_hash)
+                    enriched = []
+                    for orig_bytes, new_bytes, desc in events:
+                        new_hash_hex = (
+                            new_bytes.hex()
+                            if isinstance(new_bytes, bytes)
+                            else str(new_bytes)
+                        )
+                        enriched.append(
+                            ChainTransformation(
+                                description=desc,
+                                new_data_hash=new_hash_hex,
+                            )
+                        )
+                        if new_hash_hex not in visited:
+                            to_visit.append((new_hash_hex, current_depth + 1))
+                    if enriched:
+                        record.transformations = enriched
+                except Exception as e:
+                    logger.warning("Event query failed for %s: %s", current_hash, e)
+                    for t in record.transformations:
+                        if t.new_data_hash and t.new_data_hash not in visited:
+                            to_visit.append((t.new_data_hash, current_depth + 1))
+
+                try:
+                    reverse_events = self._contract.get_transformations_to(current_hash)
+                    for orig_bytes, new_bytes, desc in reverse_events:
+                        orig_hash = (
+                            orig_bytes.hex()
+                            if isinstance(orig_bytes, bytes)
+                            else str(orig_bytes)
+                        )
+                        if orig_hash not in visited:
+                            to_visit.append((orig_hash, current_depth + 1))
+                except Exception as e:
+                    logger.warning(
+                        "Reverse event query failed for %s: %s",
+                        current_hash,
+                        e,
+                    )
+
+            chain.append(record)
+
+        logger.debug("Chain length: %d", len(chain))
 
         if verbose:
             print(f"DEBUG: Chain length: {len(chain)}")

--- a/swarm_provenance_uploader/exceptions.py
+++ b/swarm_provenance_uploader/exceptions.py
@@ -184,59 +184,16 @@ class SignatureVerificationError(NotaryError):
 
 
 # --- Chain / Blockchain Exceptions ---
+# Canonical definitions live in chain/exceptions.py; re-exported here
+# for backward compatibility.
 
-class ChainError(ProvenanceError):
-    """Base exception for blockchain-related errors."""
-    pass
-
-
-class ChainConfigurationError(ChainError):
-    """Missing dependencies, invalid config, or missing wallet key."""
-    pass
-
-
-class ChainConnectionError(ChainError):
-    """Failed to connect to RPC endpoint."""
-
-    def __init__(self, message: str, rpc_url: str = None):
-        super().__init__(message)
-        self.rpc_url = rpc_url
-
-
-class ChainTransactionError(ChainError):
-    """Transaction reverted, ran out of gas, or otherwise failed."""
-
-    def __init__(self, message: str, tx_hash: str = None):
-        super().__init__(message)
-        self.tx_hash = tx_hash
-
-
-class ChainValidationError(ChainError):
-    """Input validation failed (hash format, string lengths, batch limits)."""
-    pass
-
-
-class DataNotRegisteredError(ChainError):
-    """Data hash not found on-chain."""
-
-    def __init__(self, message: str, data_hash: str = None):
-        super().__init__(message)
-        self.data_hash = data_hash
-
-
-class DataAlreadyRegisteredError(ChainError):
-    """Data hash is already registered on-chain."""
-
-    def __init__(
-        self,
-        message: str,
-        data_hash: str = None,
-        owner: str = None,
-        timestamp: int = None,
-        data_type: str = None,
-    ):
-        super().__init__(message)
-        self.data_hash = data_hash
-        self.owner = owner
-        self.timestamp = timestamp
-        self.data_type = data_type
+from .chain.exceptions import (  # noqa: F401, E402
+    ChainError,
+    ChainConfigurationError,
+    ChainConnectionError,
+    ChainTransactionError,
+    ChainValidationError,
+    DataNotRegisteredError,
+    DataAlreadyRegisteredError,
+    TransformationAlreadyExistsError,
+)

--- a/swarm_provenance_uploader/models.py
+++ b/swarm_provenance_uploader/models.py
@@ -293,6 +293,18 @@ class TransformResult(BaseModel):
     description: str = Field(description="Transformation description")
 
 
+class MergeTransformResult(BaseModel):
+    """Result from recording an N-to-1 merge transformation on-chain."""
+    tx_hash: str = Field(description="Transaction hash")
+    block_number: int = Field(description="Block number containing the transaction")
+    gas_used: int = Field(description="Gas consumed by the transaction")
+    explorer_url: Optional[str] = Field(default=None, description="Block explorer URL for the transaction")
+    source_hashes: List[str] = Field(description="Original data hashes that were merged")
+    new_hash: str = Field(description="New (merged) data hash")
+    description: str = Field(description="Transformation description")
+    new_data_type: str = Field(description="Data type of the merged result")
+
+
 class AccessResult(BaseModel):
     """Result from recording a data access on-chain."""
     tx_hash: str = Field(description="Transaction hash")

--- a/tests/test_chain_client.py
+++ b/tests/test_chain_client.py
@@ -12,6 +12,7 @@ from swarm_provenance_uploader.exceptions import (
     ChainValidationError,
     DataAlreadyRegisteredError,
     DataNotRegisteredError,
+    TransformationAlreadyExistsError,
 )
 from swarm_provenance_uploader.models import (
     AnchorResult,
@@ -19,6 +20,7 @@ from swarm_provenance_uploader.models import (
     ChainProvenanceRecord,
     ChainWalletInfo,
     DataStatusEnum,
+    MergeTransformResult,
     TransformResult,
 )
 
@@ -28,7 +30,7 @@ DUMMY_PRIVATE_KEY = "0x" + "a" * 64
 DUMMY_ADDRESS = "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00"
 DUMMY_HASH = "a" * 64
 DUMMY_HASH_BYTES = bytes.fromhex(DUMMY_HASH)
-DUMMY_CONTRACT = "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64"
+DUMMY_CONTRACT = "0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a"
 DUMMY_TX_HASH_BYTES = bytes.fromhex("bb" * 32)
 ZERO_ADDRESS = "0x" + "0" * 40
 
@@ -359,7 +361,7 @@ class TestChainProvider:
 
         assert provider.chain == "base-sepolia"
         assert provider.chain_id == 84532
-        assert provider.contract_address == "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64"
+        assert provider.contract_address == "0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a"
 
     def test_custom_rpc_url(self, mock_chain_deps):
         """Tests that custom RPC URL is used."""
@@ -397,7 +399,7 @@ class TestChainProvider:
         from swarm_provenance_uploader.chain.provider import ChainProvider
 
         provider = ChainProvider(chain="base-sepolia")
-        assert provider.explorer_url == "https://sepolia.basescan.org"
+        assert provider.explorer_url == "https://base-sepolia.blockscout.com"
 
     def test_custom_explorer_url_in_tx_url(self, mock_chain_deps):
         """Tests that custom explorer URL is used in generated TX URLs."""
@@ -460,7 +462,7 @@ class TestChainProvider:
 
         provider = ChainProvider(chain="base-sepolia")
         url = provider.get_explorer_tx_url("0xabc123")
-        assert url == "https://sepolia.basescan.org/tx/0xabc123"
+        assert url == "https://base-sepolia.blockscout.com/tx/0xabc123"
 
     def test_explorer_tx_url_without_prefix(self, mock_chain_deps):
         """Tests explorer URL auto-adds 0x prefix."""
@@ -468,7 +470,7 @@ class TestChainProvider:
 
         provider = ChainProvider(chain="base-sepolia")
         url = provider.get_explorer_tx_url("abc123")
-        assert url == "https://sepolia.basescan.org/tx/0xabc123"
+        assert url == "https://base-sepolia.blockscout.com/tx/0xabc123"
 
     def test_explorer_address_url(self, mock_chain_deps):
         """Tests generating address explorer URL."""
@@ -476,7 +478,7 @@ class TestChainProvider:
 
         provider = ChainProvider(chain="base-sepolia")
         url = provider.get_explorer_address_url(DUMMY_ADDRESS)
-        assert "sepolia.basescan.org/address/" in url
+        assert "base-sepolia.blockscout.com/address/" in url
 
 
 # --- Wallet tests ---
@@ -598,7 +600,7 @@ class TestChainClientAnchor:
         assert result.owner == DUMMY_ADDRESS
         assert result.block_number == 12345679
         assert result.gas_used == 95_000
-        assert "sepolia.basescan.org" in result.explorer_url
+        assert "base-sepolia.blockscout.com" in result.explorer_url
 
     def test_anchor_default_data_type(self, mock_chain_deps):
         """Tests anchor uses default data type."""
@@ -1313,3 +1315,862 @@ class TestBatchSetDataStatus:
 
         assert isinstance(result, AnchorResult)
         assert result.swarm_hash == DUMMY_HASH
+
+
+# ============================================================
+# V2 Contract Feature Tests
+# ============================================================
+
+
+class TestV2ContractDetection:
+    """Tests for v2 contract auto-detection via supports_transformation_links."""
+
+    def test_detects_v2_contract(self, mock_chain_deps):
+        """Tests that v2 contract is detected when getTransformationLinks succeeds."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract
+
+        mock_chain_deps["contract"].functions.getTransformationLinks.return_value.call.return_value = []
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+        assert contract.supports_transformation_links() is True
+
+    def test_detects_v1_contract(self, mock_chain_deps):
+        """Tests that v1 contract is detected when getTransformationLinks reverts."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract
+
+        mock_chain_deps["contract"].functions.getTransformationLinks.return_value.call.side_effect = Exception("revert")
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+        assert contract.supports_transformation_links() is False
+
+    def test_v2_detection_cached(self, mock_chain_deps):
+        """Tests that v2 detection result is cached after first call."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract
+
+        mock_chain_deps["contract"].functions.getTransformationLinks.return_value.call.return_value = []
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+        contract.supports_transformation_links()
+        contract.supports_transformation_links()
+
+        # Should only have been called once (cached after first call)
+        assert mock_chain_deps["contract"].functions.getTransformationLinks.return_value.call.call_count == 1
+
+
+class TestV2ViewMethods:
+    """Tests for v2 state-based view methods."""
+
+    def test_get_transformation_links(self, mock_chain_deps):
+        """Tests get_transformation_links returns parsed tuples."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract
+
+        new_hash_bytes = bytes.fromhex("bb" * 32)
+        mock_chain_deps["contract"].functions.getTransformationLinks.return_value.call.return_value = [
+            (new_hash_bytes, "filtered PII"),
+        ]
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+        links = contract.get_transformation_links(DUMMY_HASH)
+
+        assert len(links) == 1
+        assert links[0][0] == new_hash_bytes
+        assert links[0][1] == "filtered PII"
+
+    def test_get_child_hashes(self, mock_chain_deps):
+        """Tests get_child_hashes returns list of bytes."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract
+
+        child1 = bytes.fromhex("bb" * 32)
+        child2 = bytes.fromhex("cc" * 32)
+        mock_chain_deps["contract"].functions.getChildHashes.return_value.call.return_value = [child1, child2]
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+        children = contract.get_child_hashes(DUMMY_HASH)
+
+        assert len(children) == 2
+        assert children[0] == child1
+        assert children[1] == child2
+
+    def test_get_transformation_parents(self, mock_chain_deps):
+        """Tests get_transformation_parents returns list of bytes."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract
+
+        parent = bytes.fromhex("cc" * 32)
+        mock_chain_deps["contract"].functions.getTransformationParents.return_value.call.return_value = [parent]
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+        parents = contract.get_transformation_parents(DUMMY_HASH)
+
+        assert len(parents) == 1
+        assert parents[0] == parent
+
+
+class TestMergeTransformValidation:
+    """Tests for merge transformation validation."""
+
+    def test_merge_too_few_sources(self, mock_chain_deps):
+        """Tests that fewer than MIN_MERGE_SOURCES raises validation error."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+
+        with pytest.raises(ChainValidationError) as exc_info:
+            contract.build_record_merge_transformation_tx(
+                source_hashes=[DUMMY_HASH],  # only 1, need at least 2
+                new_hash="b" * 64,
+                description="merge",
+                new_data_type="merged",
+                sender=DUMMY_ADDRESS,
+            )
+        assert "at least" in str(exc_info.value).lower()
+
+    def test_merge_too_many_sources(self, mock_chain_deps):
+        """Tests that exceeding MAX_MERGE_SOURCES raises validation error."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract, MAX_MERGE_SOURCES
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+
+        with pytest.raises(ChainValidationError) as exc_info:
+            contract.build_record_merge_transformation_tx(
+                source_hashes=[DUMMY_HASH] * (MAX_MERGE_SOURCES + 1),
+                new_hash="b" * 64,
+                description="merge",
+                new_data_type="merged",
+                sender=DUMMY_ADDRESS,
+            )
+        assert "maximum" in str(exc_info.value).lower()
+
+    def test_merge_valid_build(self, mock_chain_deps):
+        """Tests successful merge tx build with valid inputs."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract
+
+        mock_chain_deps["contract"].functions.recordMergeTransformation.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+        tx = contract.build_record_merge_transformation_tx(
+            source_hashes=[DUMMY_HASH, "b" * 64],
+            new_hash="c" * 64,
+            description="merged two datasets",
+            new_data_type="merged",
+            sender=DUMMY_ADDRESS,
+        )
+        assert tx["from"] == DUMMY_ADDRESS
+
+
+class TestMergeTransformClient:
+    """Tests for ChainClient.merge_transform method."""
+
+    def test_merge_transform_success(self, mock_chain_deps):
+        """Tests successful merge transform via ChainClient."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        mock_chain_deps["contract"].functions.recordMergeTransformation.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+
+        client = ChainClient(chain="base-sepolia")
+        result = client.merge_transform(
+            source_hashes=[DUMMY_HASH, "b" * 64],
+            new_hash="c" * 64,
+            description="merged",
+            new_data_type="combined",
+        )
+
+        assert isinstance(result, MergeTransformResult)
+        assert result.source_hashes == [DUMMY_HASH, "b" * 64]
+        assert result.new_hash == "c" * 64
+        assert result.description == "merged"
+        assert result.new_data_type == "combined"
+        assert result.block_number == 12345679
+        assert result.gas_used == 95_000
+
+
+class TestDuplicateTransformPreCheck:
+    """Tests for duplicate transformation pre-checks in ChainClient.transform."""
+
+    def test_v2_duplicate_raises_error(self, mock_chain_deps):
+        """Tests that v2 state-based duplicate check raises TransformationAlreadyExistsError."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        new_hash = "b" * 64
+        new_hash_bytes = bytes.fromhex(new_hash)
+
+        # V2 detection: getTransformationLinks succeeds
+        mock_chain_deps["contract"].functions.getTransformationLinks.return_value.call.return_value = [
+            (new_hash_bytes, "already done"),
+        ]
+
+        client = ChainClient(chain="base-sepolia")
+        with pytest.raises(TransformationAlreadyExistsError) as exc_info:
+            client.transform(
+                original_hash=DUMMY_HASH,
+                new_hash=new_hash,
+                description="filter again",
+            )
+        assert exc_info.value.original_hash == DUMMY_HASH
+        assert exc_info.value.new_hash == new_hash
+        assert exc_info.value.existing_description == "already done"
+
+    def test_v2_no_duplicate_proceeds(self, mock_chain_deps):
+        """Tests that v2 duplicate check passes when no match."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        # V2 detection: succeeds but returns empty list
+        mock_chain_deps["contract"].functions.getTransformationLinks.return_value.call.return_value = []
+
+        client = ChainClient(chain="base-sepolia")
+        result = client.transform(
+            original_hash=DUMMY_HASH,
+            new_hash="b" * 64,
+            description="new transform",
+        )
+        assert isinstance(result, TransformResult)
+
+    def test_v1_event_cache_duplicate_raises_error(self, mock_chain_deps):
+        """Tests that v1 event-cache-based duplicate check raises error."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+        from swarm_provenance_uploader.chain.event_cache import clear_registry
+
+        # Clear any cached state from prior tests
+        clear_registry()
+
+        new_hash = "b" * 64
+
+        # Mock the event cache
+        mock_cache = MagicMock()
+        forward_map = {DUMMY_HASH: [(new_hash, "existing desc")]}
+        mock_cache.get_maps.return_value = (forward_map, {})
+
+        with patch("swarm_provenance_uploader.chain.event_cache.get_cache", return_value=mock_cache):
+            client = ChainClient(chain="base-sepolia")
+            # Force v1 mode — bypass auto-detection which depends on mock state
+            client._contract._supports_v2 = False
+            with pytest.raises(TransformationAlreadyExistsError) as exc_info:
+                client.transform(
+                    original_hash=DUMMY_HASH,
+                    new_hash=new_hash,
+                    description="try again",
+                )
+            assert exc_info.value.existing_description == "existing desc"
+
+
+class TestAnchorRevertDetection:
+    """Tests for detecting 'already registered' reverts in anchor."""
+
+    def test_anchor_revert_already_registered(self, mock_chain_deps):
+        """Tests that 'already registered' revert is caught and re-raised."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        # Pre-check: not registered (zero-address owner)
+        call_count = [0]
+        def mock_get_data_record(data_hash):
+            call_count[0] += 1
+            mock_call = MagicMock()
+            if call_count[0] == 1:
+                # First call (pre-check): not registered
+                mock_call.call.return_value = (
+                    DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+                )
+            else:
+                # Second call (after revert): now registered
+                mock_call.call.return_value = (
+                    DUMMY_HASH_BYTES, DUMMY_ADDRESS, 1700000000, "swarm-provenance", [], [], 0,
+                )
+            return mock_call
+
+        mock_chain_deps["contract"].functions.getDataRecord = mock_get_data_record
+
+        # Transaction fails with "already registered" revert
+        mock_chain_deps["web3_instance"].eth.send_raw_transaction.side_effect = Exception(
+            "execution reverted: Data already registered"
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        with pytest.raises(DataAlreadyRegisteredError) as exc_info:
+            client.anchor(swarm_hash=DUMMY_HASH)
+        assert exc_info.value.data_hash == DUMMY_HASH
+        assert exc_info.value.owner == DUMMY_ADDRESS
+
+
+class TestV2TransformationParsing:
+    """Tests for parsing v2 TransformationLink tuples in ChainClient.get()."""
+
+    def test_get_with_v2_transformation_links(self, mock_chain_deps):
+        """Tests that v2 TransformationLink tuples are parsed correctly."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        new_hash_bytes = bytes.fromhex("bb" * 32)
+        # Contract returns TransformationLink[] (list of (bytes32, string) tuples)
+        mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            DUMMY_ADDRESS,
+            1700000000,
+            "swarm-provenance",
+            [(new_hash_bytes, "filtered PII")],  # v2 tuple format
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        record = client.get(swarm_hash=DUMMY_HASH)
+
+        assert len(record.transformations) == 1
+        assert record.transformations[0].description == "filtered PII"
+        assert record.transformations[0].new_data_hash == "bb" * 32
+
+    def test_get_with_mixed_v1_strings(self, mock_chain_deps):
+        """Tests that v1 string descriptions are parsed correctly."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            DUMMY_ADDRESS,
+            1700000000,
+            "swarm-provenance",
+            ["plain string description"],  # v1 format
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        record = client.get(swarm_hash=DUMMY_HASH)
+
+        assert len(record.transformations) == 1
+        assert record.transformations[0].description == "plain string description"
+        assert record.transformations[0].new_data_hash is None
+
+
+class TestV1Fallback:
+    """Tests for v1 fallback when getDataRecord decode fails."""
+
+    def test_get_data_record_v1_fallback(self, mock_chain_deps):
+        """Tests fallback to dataRecords() when v2 ABI decode fails on v1."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract
+
+        # getDataRecord fails (v2 ABI decode error on v1 contract)
+        mock_chain_deps["contract"].functions.getDataRecord.return_value.call.side_effect = OverflowError("decode")
+        # getTransformationLinks also fails (v1 contract)
+        mock_chain_deps["contract"].functions.getTransformationLinks.return_value.call.side_effect = Exception("revert")
+        # dataRecords returns scalar-only tuple
+        mock_chain_deps["contract"].functions.dataRecords.return_value.call.return_value = (
+            DUMMY_HASH_BYTES, DUMMY_ADDRESS, 1700000000, "swarm-provenance", 0
+        )
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+        record = contract.get_data_record(DUMMY_HASH)
+
+        # Should return 7-element tuple with empty arrays for transformations/accessors
+        assert record[0] == DUMMY_HASH_BYTES
+        assert record[1] == DUMMY_ADDRESS
+        assert record[4] == []  # transformations (empty)
+        assert record[5] == []  # accessors (empty)
+
+
+class TestEventCache:
+    """Tests for TransformationEventCache singleton and scanning."""
+
+    def setup_method(self):
+        """Clear event cache registry before each test."""
+        from swarm_provenance_uploader.chain.event_cache import clear_registry
+        clear_registry()
+
+    def test_singleton_pattern(self):
+        """Tests that get_cache returns the same instance for same key."""
+        from swarm_provenance_uploader.chain.event_cache import get_cache
+
+        cache1 = get_cache("base-sepolia", DUMMY_CONTRACT)
+        cache2 = get_cache("base-sepolia", DUMMY_CONTRACT)
+        assert cache1 is cache2
+
+    def test_different_keys_different_instances(self):
+        """Tests that different chain/contract combos get different caches."""
+        from swarm_provenance_uploader.chain.event_cache import get_cache
+
+        cache1 = get_cache("base-sepolia", DUMMY_CONTRACT)
+        cache2 = get_cache("base", "0x" + "11" * 20)
+        assert cache1 is not cache2
+
+    def test_case_insensitive_address(self):
+        """Tests that contract address lookup is case-insensitive."""
+        from swarm_provenance_uploader.chain.event_cache import get_cache
+
+        cache1 = get_cache("base-sepolia", "0xABCDEF")
+        cache2 = get_cache("base-sepolia", "0xabcdef")
+        assert cache1 is cache2
+
+    def test_full_scan_populates_maps(self):
+        """Tests that first get_maps call does full scan."""
+        from swarm_provenance_uploader.chain.event_cache import TransformationEventCache
+
+        cache = TransformationEventCache()
+        mock_contract = MagicMock()
+
+        orig = bytes.fromhex("aa" * 32)
+        new = bytes.fromhex("bb" * 32)
+        mock_contract.get_all_transformations.return_value = [
+            (orig, new, "filtered"),
+        ]
+        mock_contract.get_all_merge_events.return_value = []
+
+        forward, reverse = cache.get_maps(mock_contract, deploy_block=0, current_block=1000)
+
+        assert orig.hex() in forward
+        assert new.hex() in reverse
+        assert forward[orig.hex()] == [(new.hex(), "filtered")]
+        assert reverse[new.hex()] == [(orig.hex(), "filtered")]
+
+    def test_incremental_scan(self):
+        """Tests that subsequent get_maps call scans only new blocks."""
+        from swarm_provenance_uploader.chain.event_cache import TransformationEventCache
+
+        cache = TransformationEventCache()
+        mock_contract = MagicMock()
+        mock_contract.get_all_transformations.return_value = []
+        mock_contract.get_all_merge_events.return_value = []
+
+        # First scan: blocks 0-1000
+        cache.get_maps(mock_contract, deploy_block=0, current_block=1000)
+        mock_contract.get_all_transformations.assert_called_with(from_block=0, to_block=1000)
+
+        # Second scan: should start from 1001
+        mock_contract.get_all_transformations.reset_mock()
+        cache.get_maps(mock_contract, deploy_block=0, current_block=2000)
+        mock_contract.get_all_transformations.assert_called_with(from_block=1001, to_block=2000)
+
+    def test_no_rescan_when_current(self):
+        """Tests that get_maps skips scan when already at current block."""
+        from swarm_provenance_uploader.chain.event_cache import TransformationEventCache
+
+        cache = TransformationEventCache()
+        mock_contract = MagicMock()
+        mock_contract.get_all_transformations.return_value = []
+        mock_contract.get_all_merge_events.return_value = []
+
+        cache.get_maps(mock_contract, deploy_block=0, current_block=1000)
+        mock_contract.get_all_transformations.reset_mock()
+
+        # Same current_block — should not scan again
+        cache.get_maps(mock_contract, deploy_block=0, current_block=1000)
+        mock_contract.get_all_transformations.assert_not_called()
+
+    def test_merge_events_populate_maps(self):
+        """Tests that DataMerged events populate forward and reverse maps."""
+        from swarm_provenance_uploader.chain.event_cache import TransformationEventCache
+
+        cache = TransformationEventCache()
+        mock_contract = MagicMock()
+        mock_contract.get_all_transformations.return_value = []
+
+        src1 = bytes.fromhex("aa" * 32)
+        src2 = bytes.fromhex("bb" * 32)
+        new = bytes.fromhex("cc" * 32)
+
+        merge_event = MagicMock()
+        merge_event.args.newDataHash = new
+        merge_event.args.sourceDataHashes = [src1, src2]
+        merge_event.args.transformation = "merged"
+        mock_contract.get_all_merge_events.return_value = [merge_event]
+
+        forward, reverse = cache.get_maps(mock_contract, deploy_block=0, current_block=1000)
+
+        # Both sources should map forward to new
+        assert (new.hex(), "merged") in forward[src1.hex()]
+        assert (new.hex(), "merged") in forward[src2.hex()]
+        # Reverse: new should map back to both sources
+        reverse_srcs = [src for src, _ in reverse[new.hex()]]
+        assert src1.hex() in reverse_srcs
+        assert src2.hex() in reverse_srcs
+
+    def test_merge_events_skipped_on_v1(self):
+        """Tests that DataMerged scan failure is silently skipped (v1 contracts)."""
+        from swarm_provenance_uploader.chain.event_cache import TransformationEventCache
+
+        cache = TransformationEventCache()
+        mock_contract = MagicMock()
+        mock_contract.get_all_transformations.return_value = []
+        mock_contract.get_all_merge_events.side_effect = Exception("no DataMerged event")
+
+        # Should not raise
+        forward, reverse = cache.get_maps(mock_contract, deploy_block=0, current_block=1000)
+        assert forward == {}
+        assert reverse == {}
+
+
+class TestChunkedEventQueries:
+    """Tests for chunked event log queries."""
+
+    def test_chunked_query_splits_range(self, mock_chain_deps):
+        """Tests that large ranges are split into chunks."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+
+        mock_event = MagicMock()
+        mock_event.get_logs.return_value = []
+
+        # Query a range larger than _EVENT_CHUNK_SIZE
+        contract._get_logs_chunked(mock_event, None, 0, 25_000)
+
+        # Should have been called 3 times: 0-9999, 10000-19999, 20000-25000
+        assert mock_event.get_logs.call_count == 3
+
+    def test_chunked_query_retries_on_413(self, mock_chain_deps):
+        """Tests that 413 error triggers chunk halving."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+
+        mock_event = MagicMock()
+        # First call fails with 413, halved retries succeed
+        call_count = [0]
+        def side_effect(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise Exception("413 Payload Too Large")
+            return []
+
+        mock_event.get_logs.side_effect = side_effect
+
+        # Small range that fits in one chunk normally
+        result = contract._get_logs_chunked(mock_event, None, 0, 100)
+        assert result == []
+        # Should have retried with halved chunks after 413
+        assert call_count[0] == 3  # 1 failed + 2 halved
+
+
+class TestRPCFallback:
+    """Tests for RPC failover in ChainProvider."""
+
+    def test_fallback_on_health_check(self, mock_chain_deps):
+        """Tests that health_check tries fallback on failure."""
+        from swarm_provenance_uploader.chain.provider import ChainProvider
+
+        # First connection fails, reconnect with fallback succeeds
+        call_count = [0]
+        def is_connected_side_effect():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return False  # Primary fails
+            return True  # Fallback succeeds
+
+        mock_chain_deps["web3_instance"].is_connected.side_effect = is_connected_side_effect
+
+        provider = ChainProvider(chain="base-sepolia")
+        # The fallback logic creates new Web3 instances, so we need to mock that
+        # Since _try_fallback creates new Web3 instances, and the mock_web3_class
+        # returns mock_web3_instance for all calls, the fallback should work
+        result = provider.health_check()
+        assert result is True
+
+    def test_fallback_urls_from_preset(self, mock_chain_deps):
+        """Tests that preset fallback URLs are populated."""
+        from swarm_provenance_uploader.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia")
+        # Should have primary + 2 fallbacks from preset
+        assert len(provider._rpc_urls) == 3
+        assert provider._rpc_urls[0] == "https://sepolia.base.org"
+
+    def test_custom_rpc_no_fallbacks(self, mock_chain_deps):
+        """Tests that custom RPC with no explicit fallbacks has only primary."""
+        from swarm_provenance_uploader.chain.provider import ChainProvider
+
+        provider = ChainProvider(
+            chain="base-sepolia",
+            rpc_url="https://custom.rpc.io",
+        )
+        assert len(provider._rpc_urls) == 1
+
+    def test_explicit_fallbacks_override_preset(self, mock_chain_deps):
+        """Tests that explicit rpc_fallbacks overrides preset."""
+        from swarm_provenance_uploader.chain.provider import ChainProvider
+
+        provider = ChainProvider(
+            chain="base-sepolia",
+            rpc_fallbacks=["https://fb1.io", "https://fb2.io"],
+        )
+        assert len(provider._rpc_urls) == 3
+        assert provider._rpc_urls[1] == "https://fb1.io"
+
+
+class TestProviderEnhancements:
+    """Tests for new provider features: localhost, deploy_block, Optional explorer."""
+
+    def test_localhost_preset(self, mock_chain_deps):
+        """Tests localhost preset initialization."""
+        from swarm_provenance_uploader.chain.provider import ChainProvider
+
+        # Localhost auto-detects chain ID from node
+        mock_chain_deps["web3_instance"].eth.chain_id = 31337
+        provider = ChainProvider(
+            chain="localhost",
+            rpc_url="http://127.0.0.1:8545",
+        )
+        assert provider.chain == "localhost"
+        assert provider.contract_address == "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+        assert provider.deploy_block == 0
+
+    def test_explorer_url_none_for_localhost(self, mock_chain_deps):
+        """Tests that localhost has no explorer URL."""
+        from swarm_provenance_uploader.chain.provider import ChainProvider
+
+        mock_chain_deps["web3_instance"].eth.chain_id = 31337
+        provider = ChainProvider(
+            chain="localhost",
+            rpc_url="http://127.0.0.1:8545",
+        )
+        assert provider.explorer_url is None
+        assert provider.get_explorer_tx_url("0xabc") is None
+        assert provider.get_explorer_address_url("0xabc") is None
+
+    def test_deploy_block_populated(self, mock_chain_deps):
+        """Tests that deploy_block is set from preset."""
+        from swarm_provenance_uploader.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia")
+        assert provider.deploy_block == 39_075_766
+
+
+class TestProvenanceChainV2StateReads:
+    """Tests for provenance chain traversal using v2 state reads."""
+
+    def test_v2_state_traversal(self, mock_chain_deps):
+        """Tests provenance chain traversal using v2 getTransformationLinks."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        hash_a = DUMMY_HASH
+        hash_b = "b" * 64
+        hash_a_bytes = bytes.fromhex(hash_a)
+        hash_b_bytes = bytes.fromhex(hash_b)
+
+        # V2 detection: succeeds
+        mock_chain_deps["contract"].functions.getTransformationLinks.return_value.call.return_value = []
+
+        # getDataRecord returns different records for hash_a and hash_b
+        def mock_get_data_record(data_hash):
+            mock_call = MagicMock()
+            if data_hash == hash_a_bytes:
+                mock_call.call.return_value = (
+                    hash_a_bytes, DUMMY_ADDRESS, 1700000000, "swarm-provenance",
+                    [], [], 0,
+                )
+            elif data_hash == hash_b_bytes:
+                mock_call.call.return_value = (
+                    hash_b_bytes, DUMMY_ADDRESS, 1700000001, "swarm-provenance",
+                    [], [], 0,
+                )
+            else:
+                mock_call.call.return_value = (data_hash, ZERO_ADDRESS, 0, "", [], [], 0)
+            return mock_call
+
+        mock_chain_deps["contract"].functions.getDataRecord = mock_get_data_record
+
+        # getTransformationLinks for hash_a returns link to hash_b
+        def mock_get_links(data_hash):
+            mock_call = MagicMock()
+            if data_hash == hash_a_bytes:
+                mock_call.call.return_value = [(hash_b_bytes, "filtered")]
+            else:
+                mock_call.call.return_value = []
+            return mock_call
+
+        mock_chain_deps["contract"].functions.getTransformationLinks = mock_get_links
+
+        # getTransformationParents
+        def mock_get_parents(data_hash):
+            mock_call = MagicMock()
+            if data_hash == hash_b_bytes:
+                mock_call.call.return_value = [hash_a_bytes]
+            else:
+                mock_call.call.return_value = []
+            return mock_call
+
+        mock_chain_deps["contract"].functions.getTransformationParents = mock_get_parents
+
+        client = ChainClient(chain="base-sepolia")
+        chain = client.get_provenance_chain(swarm_hash=hash_a)
+
+        assert len(chain) == 2
+        chain_hashes = [r.data_hash for r in chain]
+        assert hash_a in chain_hashes
+        assert hash_b in chain_hashes
+
+    def test_v2_cycle_detection(self, mock_chain_deps):
+        """Tests that provenance chain traversal detects cycles."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        hash_a = DUMMY_HASH
+        hash_b = "b" * 64
+        hash_a_bytes = bytes.fromhex(hash_a)
+        hash_b_bytes = bytes.fromhex(hash_b)
+
+        # V2 detection: succeeds
+        mock_chain_deps["contract"].functions.getTransformationLinks.return_value.call.return_value = []
+
+        def mock_get_data_record(data_hash):
+            mock_call = MagicMock()
+            if data_hash == hash_a_bytes:
+                mock_call.call.return_value = (hash_a_bytes, DUMMY_ADDRESS, 1700000000, "type", [], [], 0)
+            elif data_hash == hash_b_bytes:
+                mock_call.call.return_value = (hash_b_bytes, DUMMY_ADDRESS, 1700000001, "type", [], [], 0)
+            else:
+                mock_call.call.return_value = (data_hash, ZERO_ADDRESS, 0, "", [], [], 0)
+            return mock_call
+
+        mock_chain_deps["contract"].functions.getDataRecord = mock_get_data_record
+
+        # Create a cycle: A -> B -> A
+        def mock_get_links(data_hash):
+            mock_call = MagicMock()
+            if data_hash == hash_a_bytes:
+                mock_call.call.return_value = [(hash_b_bytes, "step1")]
+            elif data_hash == hash_b_bytes:
+                mock_call.call.return_value = [(hash_a_bytes, "step2")]
+            else:
+                mock_call.call.return_value = []
+            return mock_call
+
+        mock_chain_deps["contract"].functions.getTransformationLinks = mock_get_links
+        mock_chain_deps["contract"].functions.getTransformationParents.return_value.call.return_value = []
+
+        client = ChainClient(chain="base-sepolia")
+        chain = client.get_provenance_chain(swarm_hash=hash_a)
+
+        # Should visit each node exactly once despite cycle
+        assert len(chain) == 2
+
+
+class TestTransformationAlreadyExistsExceptionFields:
+    """Tests for TransformationAlreadyExistsError exception fields."""
+
+    def test_stores_all_fields(self):
+        """Tests that all fields are stored on the exception."""
+        err = TransformationAlreadyExistsError(
+            "duplicate",
+            original_hash="aa" * 32,
+            new_hash="bb" * 32,
+            existing_description="already done",
+        )
+        assert err.original_hash == "aa" * 32
+        assert err.new_hash == "bb" * 32
+        assert err.existing_description == "already done"
+        assert "duplicate" in str(err)
+
+    def test_inherits_from_chain_error(self):
+        """Tests that TransformationAlreadyExistsError is a ChainError."""
+        from swarm_provenance_uploader.exceptions import ChainError, ProvenanceError
+
+        err = TransformationAlreadyExistsError("test")
+        assert isinstance(err, ChainError)
+        assert isinstance(err, ProvenanceError)
+
+    def test_fields_default_to_none(self):
+        """Tests that optional fields default to None."""
+        err = TransformationAlreadyExistsError("test")
+        assert err.original_hash is None
+        assert err.new_hash is None
+        assert err.existing_description is None
+
+
+class TestMergeTransformResultModel:
+    """Tests for MergeTransformResult Pydantic model."""
+
+    def test_creation_and_serialization(self):
+        """Tests model creation and dump."""
+        result = MergeTransformResult(
+            tx_hash="0x" + "ab" * 32,
+            block_number=100,
+            gas_used=50000,
+            explorer_url="https://example.com/tx/0xab",
+            source_hashes=[DUMMY_HASH, "b" * 64],
+            new_hash="c" * 64,
+            description="merged datasets",
+            new_data_type="combined",
+        )
+        data = result.model_dump()
+        assert data["tx_hash"] == "0x" + "ab" * 32
+        assert data["source_hashes"] == [DUMMY_HASH, "b" * 64]
+        assert data["new_hash"] == "c" * 64
+        assert data["description"] == "merged datasets"
+        assert data["new_data_type"] == "combined"
+
+    def test_explorer_url_optional(self):
+        """Tests that explorer_url can be None."""
+        result = MergeTransformResult(
+            tx_hash="0x" + "ab" * 32,
+            block_number=100,
+            gas_used=50000,
+            explorer_url=None,
+            source_hashes=[DUMMY_HASH, "b" * 64],
+            new_hash="c" * 64,
+            description="merged",
+            new_data_type="merged",
+        )
+        assert result.explorer_url is None
+
+
+class TestABIV2Functions:
+    """Tests that the bundled ABI includes v2 functions."""
+
+    def test_abi_has_v2_functions(self):
+        """Tests that the ABI includes v2-specific functions."""
+        from swarm_provenance_uploader.chain.contract import _load_abi
+
+        abi = _load_abi()
+        func_names = [e["name"] for e in abi if e.get("type") == "function"]
+
+        assert "getTransformationLinks" in func_names
+        assert "getTransformationParents" in func_names
+        assert "getChildHashes" in func_names
+        assert "recordMergeTransformation" in func_names
+
+    def test_abi_has_data_merged_event(self):
+        """Tests that the ABI includes the DataMerged event."""
+        from swarm_provenance_uploader.chain.contract import _load_abi
+
+        abi = _load_abi()
+        event_names = [e["name"] for e in abi if e.get("type") == "event"]
+
+        assert "DataMerged" in event_names

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1702,7 +1702,7 @@ class TestDownloadWithVerify:
 # =============================================================================
 
 DUMMY_TX_HASH = "0x" + "ab" * 32
-DUMMY_EXPLORER_URL = "https://sepolia.basescan.org/tx/" + DUMMY_TX_HASH
+DUMMY_EXPLORER_URL = "https://base-sepolia.blockscout.com/tx/" + DUMMY_TX_HASH
 DUMMY_ADDRESS = "0x" + "cd" * 20
 
 
@@ -2076,7 +2076,7 @@ class TestChainBalanceCommand:
             balance_wei=1000000000000000000,
             balance_eth="1.0",
             chain="base-sepolia",
-            contract_address="0x9a3c6F47B69211F05891CCb7aD33596290b9fE64",
+            contract_address="0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a",
         )
 
         mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
@@ -2098,7 +2098,7 @@ class TestChainBalanceCommand:
             balance_wei=1000000000000000000,
             balance_eth="1.0",
             chain="base-sepolia",
-            contract_address="0x9a3c6F47B69211F05891CCb7aD33596290b9fE64",
+            contract_address="0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a",
         )
 
         mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
@@ -2121,7 +2121,7 @@ class TestChainBalanceCommand:
             balance_wei=0,
             balance_eth="0.0",
             chain="base-sepolia",
-            contract_address="0x9a3c6F47B69211F05891CCb7aD33596290b9fE64",
+            contract_address="0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a",
         )
 
         mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
@@ -3770,6 +3770,179 @@ class TestChainGasLimitFlag:
 
         assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
         assert _chain_config["gas_limit"] == 300000
+
+
+class TestChainMergeCommand:
+    """Tests for chain merge command."""
+
+    def test_merge_success(self, mocker):
+        """Tests chain merge command succeeds with 2 sources + new hash."""
+        from swarm_provenance_uploader.models import MergeTransformResult
+
+        source1 = "a" * 64
+        source2 = "b" * 64
+        new_hash = "c" * 64
+
+        mock_client = mocker.MagicMock()
+        mock_client.merge_transform.return_value = MergeTransformResult(
+            tx_hash=DUMMY_TX_HASH,
+            block_number=12350,
+            gas_used=180000,
+            explorer_url=DUMMY_EXPLORER_URL,
+            source_hashes=[source1, source2],
+            new_hash=new_hash,
+            description="Merged datasets",
+            new_data_type="merged",
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(
+            app, ["chain", "merge", source1, source2, new_hash, "--description", "Merged datasets"]
+        )
+
+        assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
+        assert "Merge transformation recorded" in result.stdout
+        assert "Sources: 2" in result.stdout
+        mock_client.merge_transform.assert_called_once_with(
+            source_hashes=[source1, source2],
+            new_hash=new_hash,
+            description="Merged datasets",
+            new_data_type="merged",
+            verbose=False,
+        )
+
+    def test_merge_too_few_args(self, mocker):
+        """Tests chain merge fails with fewer than 3 hashes."""
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client")
+
+        result = runner.invoke(app, ["chain", "merge", "a" * 64, "b" * 64])
+
+        assert result.exit_code == 1
+        assert "at least 3 hashes" in result.stdout.lower() or "2+ source" in result.stdout
+
+    def test_merge_json_output(self, mocker):
+        """Tests chain merge with --json output."""
+        from swarm_provenance_uploader.models import MergeTransformResult
+
+        source1 = "a" * 64
+        source2 = "b" * 64
+        new_hash = "c" * 64
+
+        mock_client = mocker.MagicMock()
+        mock_client.merge_transform.return_value = MergeTransformResult(
+            tx_hash=DUMMY_TX_HASH,
+            block_number=12350,
+            gas_used=180000,
+            source_hashes=[source1, source2],
+            new_hash=new_hash,
+            description="Merged",
+            new_data_type="merged",
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(
+            app, ["chain", "merge", source1, source2, new_hash, "--json"]
+        )
+
+        assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
+        import json
+        output = json.loads(result.stdout)
+        assert output["tx_hash"] == DUMMY_TX_HASH
+        assert len(output["source_hashes"]) == 2
+
+    def test_merge_source_not_registered(self, mocker):
+        """Tests chain merge when a source hash is not registered."""
+        from swarm_provenance_uploader.exceptions import DataNotRegisteredError
+
+        mock_client = mocker.MagicMock()
+        mock_client.merge_transform.side_effect = DataNotRegisteredError(
+            "Not registered", data_hash="a" * 64
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(app, ["chain", "merge", "a" * 64, "b" * 64, "c" * 64])
+
+        assert result.exit_code == 1
+        assert "not registered" in result.stdout.lower()
+
+    def test_merge_validation_error(self, mocker):
+        """Tests chain merge with validation error (e.g., too many sources)."""
+        from swarm_provenance_uploader.exceptions import ChainValidationError
+
+        mock_client = mocker.MagicMock()
+        mock_client.merge_transform.side_effect = ChainValidationError(
+            "Merge source count 51 exceeds maximum of 50"
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        hashes = ["a" * 64] * 51 + ["b" * 64]
+        result = runner.invoke(app, ["chain", "merge"] + hashes)
+
+        assert result.exit_code == 1
+        assert "Validation failed" in result.stdout
+
+    def test_merge_custom_type(self, mocker):
+        """Tests chain merge with custom data type."""
+        from swarm_provenance_uploader.models import MergeTransformResult
+
+        source1 = "a" * 64
+        source2 = "b" * 64
+        new_hash = "c" * 64
+
+        mock_client = mocker.MagicMock()
+        mock_client.merge_transform.return_value = MergeTransformResult(
+            tx_hash=DUMMY_TX_HASH,
+            block_number=12350,
+            gas_used=180000,
+            source_hashes=[source1, source2],
+            new_hash=new_hash,
+            description="Combined",
+            new_data_type="dataset",
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(
+            app, ["chain", "merge", source1, source2, new_hash,
+                  "--type", "dataset", "--description", "Combined"]
+        )
+
+        assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
+        mock_client.merge_transform.assert_called_once_with(
+            source_hashes=[source1, source2],
+            new_hash=new_hash,
+            description="Combined",
+            new_data_type="dataset",
+            verbose=False,
+        )
+
+    def test_merge_gas_flag(self, mocker):
+        """Tests chain merge with --gas flag."""
+        from swarm_provenance_uploader.models import MergeTransformResult
+
+        mock_client = mocker.MagicMock()
+        mock_client.merge_transform.return_value = MergeTransformResult(
+            tx_hash=DUMMY_TX_HASH,
+            block_number=12350,
+            gas_used=200000,
+            source_hashes=["a" * 64, "b" * 64],
+            new_hash="c" * 64,
+            description="",
+            new_data_type="merged",
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(
+            app, ["chain", "merge", "a" * 64, "b" * 64, "c" * 64, "--gas", "400000"]
+        )
+
+        assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
+        assert _chain_config["gas_limit"] == 400000
 
 
 # =============================================================================

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1128,6 +1128,359 @@ class TestBlockchainBaseSepolia:
         except Exception as e:
             pytest.skip(f"Base Sepolia test failed: {e}")
 
+    @skip_if_no_chain_wallet
+    @skip_if_no_blockchain_deps
+    def test_chain_client_transform_base_sepolia(self):
+        """Test anchoring two hashes and recording a transformation on Base Sepolia.
+
+        WARNING: Uses real testnet gas (2 anchor txs + 1 transform tx).
+        """
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+        import time
+
+        try:
+            client = ChainClient(chain="base-sepolia")
+
+            original = _random_hash()
+            derived = _random_hash()
+
+            # Anchor the original
+            r1 = client.anchor(swarm_hash=original, data_type="integration-test", verbose=True)
+            assert r1.tx_hash is not None
+            time.sleep(3)
+
+            # Record transformation
+            result = client.transform(
+                original_hash=original,
+                new_hash=derived,
+                description="sepolia integration test transform",
+                verbose=True,
+            )
+
+            print(f"\n=== Transform Result ===")
+            print(f"  Original: {original}")
+            print(f"  Derived:  {derived}")
+            print(f"  TX: {result.tx_hash}")
+            print(f"  Block: {result.block_number}")
+            print(f"  Gas: {result.gas_used}")
+
+            assert result.tx_hash is not None
+            assert result.block_number > 0
+
+            # Verify the derived hash is now registered
+            time.sleep(3)
+            assert client.verify(swarm_hash=derived) is True
+
+        except Exception as e:
+            pytest.skip(f"Base Sepolia transform failed: {e}")
+
+    @skip_if_no_chain_wallet
+    @skip_if_no_blockchain_deps
+    def test_chain_client_get_record_base_sepolia(self):
+        """Test anchoring and retrieving a full provenance record on Base Sepolia.
+
+        WARNING: Uses real testnet gas (1 anchor tx).
+        """
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+        from swarm_provenance_uploader.models import DataStatusEnum
+        import time
+
+        try:
+            client = ChainClient(chain="base-sepolia")
+
+            test_hash = _random_hash()
+            client.anchor(swarm_hash=test_hash, data_type="get-test", verbose=True)
+            time.sleep(3)
+
+            record = client.get(swarm_hash=test_hash, verbose=True)
+
+            print(f"\n=== On-chain Record ===")
+            print(f"  Hash:      {test_hash}")
+            print(f"  Owner:     {record.owner}")
+            print(f"  Type:      {record.data_type}")
+            print(f"  Status:    {record.status}")
+            print(f"  Timestamp: {record.timestamp}")
+
+            assert record.owner.startswith("0x")
+            assert record.data_type == "get-test"
+            assert record.status == DataStatusEnum.ACTIVE
+            assert record.timestamp > 0
+
+        except Exception as e:
+            pytest.skip(f"Base Sepolia get record failed: {e}")
+
+    @skip_if_no_chain_wallet
+    @skip_if_no_blockchain_deps
+    def test_chain_client_access_base_sepolia(self):
+        """Test recording data access on Base Sepolia.
+
+        WARNING: Uses real testnet gas (1 anchor tx + 1 access tx).
+        """
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+        import time
+
+        try:
+            client = ChainClient(chain="base-sepolia")
+
+            test_hash = _random_hash()
+            client.anchor(swarm_hash=test_hash, data_type="access-test", verbose=True)
+            time.sleep(3)
+
+            result = client.access(swarm_hash=test_hash, verbose=True)
+
+            print(f"\n=== Access Result ===")
+            print(f"  Hash:     {test_hash}")
+            print(f"  Accessor: {result.accessor}")
+            print(f"  TX:       {result.tx_hash}")
+            print(f"  Gas:      {result.gas_used}")
+
+            assert result.tx_hash is not None
+            assert result.accessor.startswith("0x")
+
+        except Exception as e:
+            pytest.skip(f"Base Sepolia access failed: {e}")
+
+    @skip_if_no_chain_wallet
+    @skip_if_no_blockchain_deps
+    def test_chain_client_merge_transform_base_sepolia(self):
+        """Test N-to-1 merge transformation on Base Sepolia.
+
+        WARNING: Uses real testnet gas (2 anchor txs + 1 merge tx).
+        """
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+        import time
+
+        try:
+            client = ChainClient(chain="base-sepolia")
+
+            source1 = _random_hash()
+            source2 = _random_hash()
+            merged = _random_hash()
+
+            # Anchor both sources (wait between to avoid nonce issues)
+            client.anchor(swarm_hash=source1, data_type="merge-source", verbose=True)
+            time.sleep(2)
+            client.anchor(swarm_hash=source2, data_type="merge-source", verbose=True)
+            time.sleep(3)
+
+            # Record merge
+            result = client.merge_transform(
+                source_hashes=[source1, source2],
+                new_hash=merged,
+                description="sepolia merge integration test",
+                new_data_type="merged-dataset",
+                verbose=True,
+            )
+
+            print(f"\n=== Merge Transform Result ===")
+            print(f"  Sources: {source1[:16]}..., {source2[:16]}...")
+            print(f"  Merged:  {merged[:16]}...")
+            print(f"  TX:      {result.tx_hash}")
+            print(f"  Block:   {result.block_number}")
+            print(f"  Gas:     {result.gas_used}")
+
+            assert result.tx_hash is not None
+            assert result.block_number > 0
+            assert len(result.source_hashes) == 2
+
+            # Verify merged hash is registered
+            time.sleep(3)
+            assert client.verify(swarm_hash=merged) is True
+
+        except Exception as e:
+            pytest.skip(f"Base Sepolia merge transform failed: {e}")
+
+    @skip_if_no_chain_wallet
+    @skip_if_no_blockchain_deps
+    def test_chain_client_provenance_chain_base_sepolia(self):
+        """Test provenance chain traversal on Base Sepolia.
+
+        Anchors A, transforms A->B, then walks the chain from B.
+        WARNING: Uses real testnet gas (1 anchor tx + 1 transform tx).
+        """
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+        import time
+
+        try:
+            client = ChainClient(chain="base-sepolia")
+
+            hash_a = _random_hash()
+            hash_b = _random_hash()
+
+            client.anchor(swarm_hash=hash_a, data_type="chain-test", verbose=True)
+            time.sleep(3)
+            client.transform(
+                original_hash=hash_a,
+                new_hash=hash_b,
+                description="chain walk test",
+                verbose=True,
+            )
+            time.sleep(3)
+
+            chain = client.get_provenance_chain(swarm_hash=hash_b, verbose=True)
+
+            print(f"\n=== Provenance Chain ===")
+            for i, node in enumerate(chain):
+                print(f"  [{i}] {node.data_hash[:16]}... "
+                      f"type={node.data_type} "
+                      f"transformations={len(node.transformations)}")
+
+            assert len(chain) >= 2
+            # First node should be hash_b, last should be hash_a
+            assert chain[0].data_hash == hash_b
+            assert chain[-1].data_hash == hash_a
+
+        except Exception as e:
+            pytest.skip(f"Base Sepolia provenance chain failed: {e}")
+
+    @skip_if_no_chain_wallet
+    @skip_if_no_blockchain_deps
+    def test_chain_client_multi_hop_provenance_chain_base_sepolia(self):
+        """Test multi-hop provenance chain: A -> B -> C, walk from C back to A.
+
+        Scenario:
+          1. Anchor A (raw dataset)
+          2. Transform A -> B ("Filtered PII")
+          3. Transform B -> C ("Aggregated statistics")
+          4. Walk chain from C — expect [C, B, A]
+          5. Verify each node's data_type and transformation descriptions
+
+        WARNING: Uses real testnet gas (1 anchor + 2 transform txs).
+        """
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+        from swarm_provenance_uploader.models import DataStatusEnum
+        import time
+
+        try:
+            client = ChainClient(chain="base-sepolia")
+
+            hash_a = _random_hash()
+            hash_b = _random_hash()
+            hash_c = _random_hash()
+
+            # Step 1: Anchor the root dataset
+            r_anchor = client.anchor(
+                swarm_hash=hash_a, data_type="raw-dataset", verbose=True
+            )
+            print(f"\n=== Step 1: Anchor A ===")
+            print(f"  Hash: {hash_a[:16]}...")
+            print(f"  TX:   {r_anchor.tx_hash}")
+            time.sleep(3)
+
+            # Step 2: Transform A -> B (PII filtering)
+            r_ab = client.transform(
+                original_hash=hash_a,
+                new_hash=hash_b,
+                description="Filtered PII fields",
+                verbose=True,
+            )
+            print(f"\n=== Step 2: Transform A -> B ===")
+            print(f"  A: {hash_a[:16]}...")
+            print(f"  B: {hash_b[:16]}...")
+            print(f"  TX:   {r_ab.tx_hash}")
+            time.sleep(3)
+
+            # Step 3: Transform B -> C (aggregation)
+            r_bc = client.transform(
+                original_hash=hash_b,
+                new_hash=hash_c,
+                description="Aggregated statistics",
+                verbose=True,
+            )
+            print(f"\n=== Step 3: Transform B -> C ===")
+            print(f"  B: {hash_b[:16]}...")
+            print(f"  C: {hash_c[:16]}...")
+            print(f"  TX:   {r_bc.tx_hash}")
+            time.sleep(3)
+
+            # Step 4: Walk chain from C back to A
+            chain = client.get_provenance_chain(swarm_hash=hash_c, verbose=True)
+
+            print(f"\n=== Provenance Chain (from C) ===")
+            for i, node in enumerate(chain):
+                xforms = [t.description for t in node.transformations]
+                print(
+                    f"  [{i}] {node.data_hash[:16]}... "
+                    f"type={node.data_type} status={node.status.name} "
+                    f"transforms={xforms}"
+                )
+
+            # Should be exactly 3 nodes: C, B, A
+            assert len(chain) == 3, f"Expected 3 nodes, got {len(chain)}"
+
+            # Node 0: C (leaf — no outgoing transformations)
+            assert chain[0].data_hash == hash_c
+            assert chain[0].status == DataStatusEnum.ACTIVE
+
+            # Node 1: B (has one outgoing transformation to C)
+            assert chain[1].data_hash == hash_b
+            assert any(
+                t.description == "Aggregated statistics"
+                for t in chain[1].transformations
+            ), f"Expected 'Aggregated statistics' in B's transforms: {chain[1].transformations}"
+
+            # Node 2: A (root — has one outgoing transformation to B)
+            assert chain[2].data_hash == hash_a
+            assert chain[2].data_type == "raw-dataset"
+            assert any(
+                t.description == "Filtered PII fields"
+                for t in chain[2].transformations
+            ), f"Expected 'Filtered PII fields' in A's transforms: {chain[2].transformations}"
+
+            print(f"\n  Chain verified: C -> B -> A")
+
+        except Exception as e:
+            pytest.skip(f"Base Sepolia multi-hop provenance chain failed: {e}")
+
+    @skip_if_no_chain_wallet
+    @skip_if_no_blockchain_deps
+    def test_chain_client_duplicate_transform_precheck_base_sepolia(self):
+        """Test that duplicate transform pre-check works on Base Sepolia.
+
+        Anchors A, transforms A->B, then attempts A->B again.
+        WARNING: Uses real testnet gas (1 anchor tx + 1 transform tx).
+        """
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+        from swarm_provenance_uploader.chain.exceptions import TransformationAlreadyExistsError
+        import time
+
+        try:
+            client = ChainClient(chain="base-sepolia")
+
+            original = _random_hash()
+            derived = _random_hash()
+
+            client.anchor(swarm_hash=original, data_type="dup-test", verbose=True)
+            time.sleep(3)
+            client.transform(
+                original_hash=original,
+                new_hash=derived,
+                description="first transform",
+                verbose=True,
+            )
+            time.sleep(3)
+
+            # Attempt the same transform again — should raise
+            with pytest.raises(TransformationAlreadyExistsError) as exc_info:
+                client.transform(
+                    original_hash=original,
+                    new_hash=derived,
+                    description="duplicate attempt",
+                )
+
+            print(f"\n=== Duplicate Transform Pre-Check ===")
+            print(f"  Original:   {original[:16]}...")
+            print(f"  Derived:    {derived[:16]}...")
+            print(f"  Existing:   {exc_info.value.existing_description}")
+
+            assert exc_info.value.original_hash == original
+            assert exc_info.value.new_hash == derived
+
+        except TransformationAlreadyExistsError:
+            raise  # Re-raise so pytest.raises captures it
+        except Exception as e:
+            pytest.skip(f"Base Sepolia duplicate transform test failed: {e}")
+
 
 # =============================================================================
 # MANIFEST / COLLECTION UPLOAD TESTS


### PR DESCRIPTION
## Summary

- Rewrite chain subsystem for v2 DataProvenance contract (`0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a` on Base Sepolia)
- Auto-detect v2 contracts via `supports_transformation_links()` trial call; state-based traversal on v2, event cache fallback on v1
- Add N-to-1 merge transformations (`chain merge` CLI + `merge_transform()` API, 2-50 sources)
- Duplicate transform pre-checks before spending gas
- RPC failover with per-chain preset fallback URLs
- Chunked event queries with 413 retry and adaptive chunk halving
- Standalone `chain/exceptions.py` with `TransformationAlreadyExistsError`
- Thread-safe `TransformationEventCache` singleton per (chain, contract)
- Multi-hop provenance chain traversal verified on Base Sepolia (A→B→C)
- Version bump 0.8.3 → 0.9.0

## Changes

| Area | Files | What |
|------|-------|------|
| Core | `chain/provider.py`, `chain/contract.py`, `core/chain_client.py` | Rewritten for v2 contract, RPC failover, merge support |
| New | `chain/event_cache.py`, `chain/exceptions.py` | Event cache singleton, chain exception hierarchy |
| CLI | `cli.py` | `chain merge` command with full error handling |
| Models | `models.py`, `exceptions.py` | `MergeTransformResult`, re-exported chain exceptions |
| ABI | `chain/abi/DataProvenance.json` | Updated from ConsentsBasedDataProvenance repo |
| Tests | `test_chain_client.py`, `test_cli.py`, `test_integration.py` | 60 new unit tests, 7 merge CLI tests, 7 Base Sepolia integration tests |
| Docs | `README.md`, `CLAUDE.md`, `chain-setup.md`, `chain-workflows.md` | Merge workflow, --follow examples, file tree, architecture |

## Test plan

- [x] 635 unit tests pass (`pytest --tb=short -q`)
- [x] 12 Base Sepolia integration tests pass (anchor, transform, get, access, merge, multi-hop chain walk, duplicate pre-check)
- [x] Multi-hop provenance chain verified: A→B→C walk returns [C, B, A] with correct transformation descriptions
- [x] Merge transform verified on-chain: 2 sources + merged hash registered, 359k gas

Closes #90, #91, #92, #93, #94, #95, #96, #97, #98, #99, #100, #101, #102, #103, #104, #105