### PR TITLE
Make signature verification default on download

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,9 @@ swarm-prov-upload notary info                           # Check notary service s
 swarm-prov-upload notary status                         # Quick status check
 swarm-prov-upload notary verify --file signed.json      # Verify local file signature
 swarm-prov-upload upload --file data.txt --sign notary  # Upload with notary signing
-swarm-prov-upload download <hash> --verify              # Download with signature verification
+swarm-prov-upload download <hash>                       # Download with signature verification (default)
+swarm-prov-upload download <hash> --no-verify           # Skip signature verification
+swarm-prov-upload download <hash> --strict              # Fail if signature verification fails
 
 # Chain commands (optional, requires blockchain dependencies)
 swarm-prov-upload chain balance                                              # Wallet balance and chain info

--- a/README.md
+++ b/README.md
@@ -44,8 +44,14 @@ swarm-prov-upload download <swarm_hash> --output-dir ./downloads
 # Upload with notary signing (gateway only)
 swarm-prov-upload upload --file /path/to/data.txt --sign notary
 
-# Download with signature verification
-swarm-prov-upload download <swarm_hash> --output-dir ./downloads --verify
+# Download and verify data (signature verification is on by default)
+swarm-prov-upload download <swarm_hash> --output-dir ./downloads
+
+# Download without signature verification
+swarm-prov-upload download <swarm_hash> --output-dir ./downloads --no-verify
+
+# Download with strict verification (fail on invalid signature)
+swarm-prov-upload download <swarm_hash> --output-dir ./downloads --strict
 ```
 
 ## Setup
@@ -659,11 +665,17 @@ swarm-prov-upload notary verify --file signed_document.json
 
 #### Verification on Download
 
-```bash
-# Download and automatically verify signature
-swarm-prov-upload download <swarm_hash> --output-dir ./downloads --verify
+Signature verification is enabled by default when downloading signed documents:
 
-# If verification fails, you'll see an error with details
+```bash
+# Download with automatic verification (default)
+swarm-prov-upload download <swarm_hash> --output-dir ./downloads
+
+# Skip verification
+swarm-prov-upload download <swarm_hash> --output-dir ./downloads --no-verify
+
+# Strict mode: fail (exit 1) if verification fails
+swarm-prov-upload download <swarm_hash> --output-dir ./downloads --strict
 ```
 
 #### Signature Structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swarm-provenance-uploader"
-version = "0.9.0"
+version = "0.9.1"
 description = "A CLI toolkit for wrapping data and uploading to Swarm."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/swarm_provenance_uploader/__init__.py
+++ b/swarm_provenance_uploader/__init__.py
@@ -3,7 +3,7 @@
 import subprocess
 from pathlib import Path
 
-__version_base__ = "0.9.0"
+__version_base__ = "0.9.1"
 
 
 def _get_git_hash() -> str:

--- a/swarm_provenance_uploader/cli.py
+++ b/swarm_provenance_uploader/cli.py
@@ -550,15 +550,19 @@ def download(
         default_factory=lambda: Path.cwd()  # Default to current working directory
     )],
     bee_url: Annotated[Optional[str], typer.Option("--bee-url", help="Bee Gateway URL (when backend=local).")] = None,
-    verify: Annotated[bool, typer.Option("--verify", help="Verify notary signature if present (gateway only for address lookup).")] = False,
+    no_verify: Annotated[bool, typer.Option("--no-verify", help="Skip notary signature verification.")] = False,
+    verify_flag: Annotated[bool, typer.Option("--verify", help="Verify notary signature (default, kept for backward compatibility).", hidden=True)] = False,
+    strict: Annotated[bool, typer.Option("--strict", help="Fail (exit 1) if signature verification fails.")] = False,
     verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable verbose output for debugging.")] = False
 ):
     """
     Downloads Provenance Metadata from Swarm, decodes the wrapped data,
     verifies its integrity, and saves both files.
 
-    Use --verify to verify notary signatures if present.
+    Notary signatures are verified by default when present.
+    Use --no-verify to skip verification, --strict to fail on invalid signatures.
     """
+    verify = not no_verify
     # Determine which backend to use
     use_gateway = _backend_config["backend"] == "gateway"
     gateway_url = _backend_config["gateway_url"]
@@ -684,11 +688,15 @@ def download(
                     typer.secho(f"  Signature: ✓ Verified", fg=typer.colors.GREEN)
                 else:
                     typer.secho(f"  Signature: ✗ FAILED - {error_msg}", fg=typer.colors.RED)
+                    if strict:
+                        typer.secho("\nAborting download (--strict mode).", fg=typer.colors.RED, err=True)
+                        raise typer.Exit(code=1)
             else:
                 typer.secho("  Cannot verify: No notary address available", fg=typer.colors.YELLOW)
                 typer.echo("  Use gateway backend or run 'notary verify' manually with --address")
         else:
-            typer.echo("\nNo notary signatures found in document.")
+            if verbose:
+                typer.echo("\nNo notary signatures found in document.")
 
     # 5. Extract Base64 encoded data
     b64_encoded_original_data = provenance_metadata_obj.data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1883,6 +1883,122 @@ class TestDownloadWithVerify:
         # Should not crash — --verify is accepted silently
         assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
 
+    def test_download_strict_no_signatures_succeeds(self, mocker, tmp_path):
+        """Tests --strict with no signatures present still succeeds."""
+        import json
+        import base64
+        import hashlib
+
+        original_data = b"test provenance data"
+        b64_data = base64.b64encode(original_data).decode()
+        content_hash = hashlib.sha256(original_data).hexdigest()
+
+        metadata = {
+            "data": b64_data,
+            "content_hash": content_hash,
+            "stamp_id": DUMMY_STAMP,
+            "provenance_standard": "TEST-V1",
+        }
+
+        mock_client = mocker.MagicMock()
+        mock_client.download_data.return_value = json.dumps(metadata).encode()
+
+        mocker.patch(
+            "swarm_provenance_uploader.cli.GatewayClient",
+            return_value=mock_client
+        )
+
+        result = runner.invoke(
+            app,
+            ["download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path), "--strict"]
+        )
+
+        # No signatures → nothing to fail on → succeeds
+        assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
+
+    def test_download_no_verify_overrides_strict(self, mocker, tmp_path):
+        """Tests --no-verify takes precedence over --strict."""
+        import json
+        import base64
+        import hashlib
+
+        original_data = b"test provenance data"
+        b64_data = base64.b64encode(original_data).decode()
+        content_hash = hashlib.sha256(original_data).hexdigest()
+
+        metadata = {
+            "data": b64_data,
+            "content_hash": content_hash,
+            "stamp_id": DUMMY_STAMP,
+            "provenance_standard": "TEST-V1",
+            "signatures": [
+                {
+                    "type": "notary",
+                    "signer": "0x1234567890abcdef1234567890abcdef12345678",
+                    "timestamp": "2026-01-21T16:30:00+00:00",
+                    "data_hash": "wrong_hash",
+                    "signature": "0x" + "00" * 65,
+                }
+            ],
+        }
+
+        mock_client = mocker.MagicMock()
+        mock_client.download_data.return_value = json.dumps(metadata).encode()
+
+        mocker.patch(
+            "swarm_provenance_uploader.cli.GatewayClient",
+            return_value=mock_client
+        )
+
+        result = runner.invoke(
+            app,
+            ["download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path), "--no-verify", "--strict"]
+        )
+
+        # --no-verify bypasses all verification, --strict never evaluated
+        assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
+        assert "Signature" not in result.stdout
+
+    def test_download_strict_local_backend_warns_not_fails(self, mocker, tmp_path):
+        """Tests --strict on local backend warns but doesn't fail (can't fetch notary address)."""
+        import json
+        import base64
+        import hashlib
+
+        original_data = b"test provenance data"
+        b64_data = base64.b64encode(original_data).decode()
+        content_hash = hashlib.sha256(original_data).hexdigest()
+
+        metadata = {
+            "data": b64_data,
+            "content_hash": content_hash,
+            "stamp_id": DUMMY_STAMP,
+            "provenance_standard": "TEST-V1",
+            "signatures": [
+                {
+                    "type": "notary",
+                    "signer": "0x1234567890abcdef1234567890abcdef12345678",
+                    "timestamp": "2026-01-21T16:30:00+00:00",
+                    "data_hash": "abc123",
+                    "signature": "0x" + "ab" * 65,
+                }
+            ],
+        }
+
+        mocker.patch(
+            "swarm_provenance_uploader.cli.swarm_client.download_data_from_swarm",
+            return_value=json.dumps(metadata).encode()
+        )
+
+        result = runner.invoke(
+            app,
+            ["--backend", "local", "download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path), "--strict"]
+        )
+
+        # Should warn but still succeed — can't verify without notary address
+        assert result.exit_code == 0
+        assert "Cannot verify" in result.stdout or "No notary address" in result.stdout
+
 
 # =============================================================================
 # CHAIN COMMANDS TESTS

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1496,10 +1496,10 @@ class TestUploadWithSign:
 
 
 class TestDownloadWithVerify:
-    """Tests for download command with --verify flag."""
+    """Tests for download command with default signature verification."""
 
     def test_download_with_verify_success(self, mocker, tmp_path):
-        """Tests download with --verify flag and valid signature."""
+        """Tests download verifies signature by default."""
         import json
         import base64
         import hashlib
@@ -1549,7 +1549,7 @@ class TestDownloadWithVerify:
 
         result = runner.invoke(
             app,
-            ["download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path), "--verify"]
+            ["download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path)]
         )
 
         assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
@@ -1557,7 +1557,7 @@ class TestDownloadWithVerify:
         assert "verified" in result.stdout.lower() or "Verified" in result.stdout
 
     def test_download_verify_fails_invalid_signature(self, mocker, tmp_path):
-        """Tests download with --verify fails when signature is invalid."""
+        """Tests download warns on invalid signature but still succeeds."""
         import json
         import base64
         import hashlib
@@ -1606,7 +1606,7 @@ class TestDownloadWithVerify:
 
         result = runner.invoke(
             app,
-            ["download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path), "--verify"]
+            ["download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path)]
         )
 
         # Download should still succeed (files downloaded) but with a warning about failed signature
@@ -1615,7 +1615,7 @@ class TestDownloadWithVerify:
         assert "FAILED" in result.stdout or "failed" in result.stdout.lower()
 
     def test_download_verify_no_signature_found(self, mocker, tmp_path):
-        """Tests download with --verify warns when no signature found."""
+        """Tests download silently skips verification when no signature present."""
         import json
         import base64
         import hashlib
@@ -1645,15 +1645,16 @@ class TestDownloadWithVerify:
 
         result = runner.invoke(
             app,
-            ["download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path), "--verify"]
+            ["download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path)]
         )
 
-        # Should still succeed (download works) but show message about no signatures
+        # Should succeed silently — no error about missing signatures
         assert result.exit_code == 0
-        assert "No notary signatures" in result.stdout or "no notary" in result.stdout.lower()
+        # No signature message should NOT appear (silent skip)
+        assert "No notary signatures" not in result.stdout
 
     def test_download_verify_local_backend_warns(self, mocker, tmp_path):
-        """Tests --verify with local backend still downloads but can't verify."""
+        """Tests default verify with local backend still downloads but can't verify."""
         import json
         import base64
         import hashlib
@@ -1688,13 +1689,199 @@ class TestDownloadWithVerify:
 
         result = runner.invoke(
             app,
-            ["--backend", "local", "download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path), "--verify"]
+            ["--backend", "local", "download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path)]
         )
 
         # Download should still succeed
         assert result.exit_code == 0
         # But should warn about not being able to verify
         assert "Cannot verify" in result.stdout or "No notary address" in result.stdout
+
+    def test_download_no_verify_skips_verification(self, mocker, tmp_path):
+        """Tests --no-verify skips signature verification entirely."""
+        import json
+        import base64
+        import hashlib
+
+        original_data = b"test provenance data"
+        b64_data = base64.b64encode(original_data).decode()
+        content_hash = hashlib.sha256(original_data).hexdigest()
+
+        metadata = {
+            "data": b64_data,
+            "content_hash": content_hash,
+            "stamp_id": DUMMY_STAMP,
+            "provenance_standard": "TEST-V1",
+            "signatures": [
+                {
+                    "type": "notary",
+                    "signer": "0x1234567890abcdef1234567890abcdef12345678",
+                    "timestamp": "2026-01-21T16:30:00+00:00",
+                    "data_hash": "abc123",
+                    "signature": "0x" + "ab" * 65,
+                }
+            ],
+        }
+
+        mock_client = mocker.MagicMock()
+        mock_client.download_data.return_value = json.dumps(metadata).encode()
+
+        mocker.patch(
+            "swarm_provenance_uploader.cli.GatewayClient",
+            return_value=mock_client
+        )
+
+        result = runner.invoke(
+            app,
+            ["download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path), "--no-verify"]
+        )
+
+        assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
+        # No verification output should appear
+        assert "Signature" not in result.stdout
+        assert "Verified" not in result.stdout
+
+    def test_download_strict_fails_on_invalid_signature(self, mocker, tmp_path):
+        """Tests --strict exits with code 1 when signature verification fails."""
+        import json
+        import base64
+        import hashlib
+        from swarm_provenance_uploader.models import NotaryInfoResponse
+
+        original_data = b"test provenance data"
+        b64_data = base64.b64encode(original_data).decode()
+        content_hash = hashlib.sha256(original_data).hexdigest()
+
+        metadata = {
+            "data": b64_data,
+            "content_hash": content_hash,
+            "stamp_id": DUMMY_STAMP,
+            "provenance_standard": "TEST-V1",
+            "signatures": [
+                {
+                    "type": "notary",
+                    "signer": "0x1234567890abcdef1234567890abcdef12345678",
+                    "timestamp": "2026-01-21T16:30:00+00:00",
+                    "data_hash": "wrong_hash",
+                    "signature": "0x" + "00" * 65,
+                }
+            ],
+        }
+
+        mock_client = mocker.MagicMock()
+        mock_client.download_data.return_value = json.dumps(metadata).encode()
+        mock_client.get_notary_info.return_value = NotaryInfoResponse(
+            enabled=True,
+            available=True,
+            address="0x1234567890abcdef1234567890abcdef12345678",
+            message=None,
+        )
+
+        mocker.patch(
+            "swarm_provenance_uploader.cli.GatewayClient",
+            return_value=mock_client
+        )
+
+        mocker.patch(
+            "swarm_provenance_uploader.core.notary_utils.verify_notary_signature",
+            return_value=(False, "Signature recovery mismatch")
+        )
+
+        result = runner.invoke(
+            app,
+            ["download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path), "--strict"]
+        )
+
+        assert result.exit_code == 1
+        assert "FAILED" in result.stdout
+        assert "strict" in result.stdout.lower() or "Aborting" in result.stdout
+
+    def test_download_strict_succeeds_on_valid_signature(self, mocker, tmp_path):
+        """Tests --strict succeeds when signature is valid."""
+        import json
+        import base64
+        import hashlib
+        from swarm_provenance_uploader.models import NotaryInfoResponse
+
+        original_data = b"test provenance data"
+        b64_data = base64.b64encode(original_data).decode()
+        content_hash = hashlib.sha256(original_data).hexdigest()
+
+        metadata = {
+            "data": b64_data,
+            "content_hash": content_hash,
+            "stamp_id": DUMMY_STAMP,
+            "provenance_standard": "TEST-V1",
+            "signatures": [
+                {
+                    "type": "notary",
+                    "signer": "0x1234567890abcdef1234567890abcdef12345678",
+                    "timestamp": "2026-01-21T16:30:00+00:00",
+                    "data_hash": "abc123",
+                    "signature": "0x" + "ab" * 65,
+                }
+            ],
+        }
+
+        mock_client = mocker.MagicMock()
+        mock_client.download_data.return_value = json.dumps(metadata).encode()
+        mock_client.get_notary_info.return_value = NotaryInfoResponse(
+            enabled=True,
+            available=True,
+            address="0x1234567890abcdef1234567890abcdef12345678",
+            message=None,
+        )
+
+        mocker.patch(
+            "swarm_provenance_uploader.cli.GatewayClient",
+            return_value=mock_client
+        )
+
+        mocker.patch(
+            "swarm_provenance_uploader.core.notary_utils.verify_notary_signature",
+            return_value=(True, None)
+        )
+
+        result = runner.invoke(
+            app,
+            ["download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path), "--strict"]
+        )
+
+        assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
+        assert "Verified" in result.stdout
+
+    def test_download_verify_flag_backward_compatible(self, mocker, tmp_path):
+        """Tests that --verify flag still works (backward compatibility)."""
+        import json
+        import base64
+        import hashlib
+
+        original_data = b"test provenance data"
+        b64_data = base64.b64encode(original_data).decode()
+        content_hash = hashlib.sha256(original_data).hexdigest()
+
+        metadata = {
+            "data": b64_data,
+            "content_hash": content_hash,
+            "stamp_id": DUMMY_STAMP,
+            "provenance_standard": "TEST-V1",
+        }
+
+        mock_client = mocker.MagicMock()
+        mock_client.download_data.return_value = json.dumps(metadata).encode()
+
+        mocker.patch(
+            "swarm_provenance_uploader.cli.GatewayClient",
+            return_value=mock_client
+        )
+
+        result = runner.invoke(
+            app,
+            ["download", DUMMY_SWARM_REF, "--output-dir", str(tmp_path), "--verify"]
+        )
+
+        # Should not crash — --verify is accepted silently
+        assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Signature verification is now **on by default** when downloading signed documents
- No signatures present → silently skipped (download proceeds normally)
- Invalid signature → warns but continues download (unless `--strict`)
- `--verify` kept as hidden no-op for backward compatibility

## New flags

| Flag | Behavior |
|------|----------|
| *(default)* | Verify signatures if present, warn on failure, always download |
| `--no-verify` | Skip verification entirely |
| `--strict` | Fail (exit 1) if signature verification fails |
| `--verify` | Hidden, backward compatible no-op |

## Test plan

- [x] 640 tests pass
- [x] Default verify with valid signature shows "Verified"
- [x] Default verify with invalid signature warns but downloads (exit 0)
- [x] No signatures → silent skip (no error message)
- [x] `--no-verify` skips all verification output
- [x] `--strict` with invalid signature → exit 1
- [x] `--strict` with valid signature → exit 0
- [x] `--verify` flag accepted silently (backward compat)
- [x] Local backend with signatures warns about missing notary address

Closes #87, closes #86