### PR TITLE
Fix x402 402 response parsing for detail wrapper (#111)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swarm-provenance-uploader"
-version = "0.9.2"
+version = "0.9.3"
 description = "A CLI toolkit for wrapping data and uploading to Swarm."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/swarm_provenance_uploader/__init__.py
+++ b/swarm_provenance_uploader/__init__.py
@@ -3,7 +3,7 @@
 import subprocess
 from pathlib import Path
 
-__version_base__ = "0.9.2"
+__version_base__ = "0.9.3"
 
 
 def _get_git_hash() -> str:

--- a/swarm_provenance_uploader/core/gateway_client.py
+++ b/swarm_provenance_uploader/core/gateway_client.py
@@ -145,6 +145,9 @@ class GatewayClient:
             # Parse 402 response for useful error message
             try:
                 body = response.json()
+                # Unwrap detail wrapper from new gateway format
+                if "detail" in body and isinstance(body["detail"], dict):
+                    body = body["detail"]
                 accepts = body.get("accepts", [])
                 if accepts:
                     amounts = [opt.get("maxAmountRequired", "?") for opt in accepts]

--- a/swarm_provenance_uploader/core/x402_client.py
+++ b/swarm_provenance_uploader/core/x402_client.py
@@ -331,7 +331,11 @@ class X402Client:
             PaymentRequiredError: If response format is invalid.
         """
         try:
-            return X402PaymentRequirements.model_validate(response_body)
+            # New gateway wraps payload in {"detail": {...}}
+            payload = response_body
+            if "detail" in response_body and "accepts" in response_body.get("detail", {}):
+                payload = response_body["detail"]
+            return X402PaymentRequirements.model_validate(payload)
         except Exception as e:
             raise PaymentRequiredError(
                 f"Failed to parse 402 response: {e}",

--- a/tests/test_gateway_client.py
+++ b/tests/test_gateway_client.py
@@ -634,6 +634,28 @@ class TestGatewayClientX402:
         )
         assert client._x402_network == "base-sepolia"
 
+    def test_402_disabled_detail_wrapped(self, requests_mock):
+        """Tests that x402-disabled path extracts amounts from detail-wrapped 402."""
+        from swarm_provenance_uploader.exceptions import PaymentRequiredError
+
+        wrapped_response = {"detail": self.SAMPLE_402_RESPONSE}
+
+        requests_mock.post(
+            "https://test.gateway.io/api/v1/stamps/",
+            status_code=402,
+            json=wrapped_response,
+        )
+
+        client = GatewayClient(base_url="https://test.gateway.io", x402_enabled=False)
+
+        with pytest.raises(PaymentRequiredError) as exc_info:
+            client.purchase_stamp(duration_hours=24)
+
+        # Should have extracted payment options from inside detail wrapper
+        assert exc_info.value.payment_options is not None
+        assert len(exc_info.value.payment_options) == 1
+        assert "50000" in str(exc_info.value)
+
     def test_402_non_json_response(self, requests_mock):
         """Tests handling of 402 with non-JSON response body."""
         from swarm_provenance_uploader.exceptions import PaymentRequiredError

--- a/tests/test_x402_client.py
+++ b/tests/test_x402_client.py
@@ -155,6 +155,30 @@ class TestX402ClientParse402:
         with pytest.raises(PaymentRequiredError):
             client.parse_402_response({"invalid": "data"})
 
+    def test_parse_402_response_detail_wrapped(self, mock_eth_deps):
+        """Tests parsing a 402 response wrapped in a detail object."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        wrapped_body = {"detail": SAMPLE_402_RESPONSE}
+        client = X402Client(skip_domain_validation=True)
+        requirements = client.parse_402_response(wrapped_body)
+
+        assert isinstance(requirements, X402PaymentRequirements)
+        assert len(requirements.accepts) == 1
+        assert requirements.accepts[0].network == "base-sepolia"
+        assert requirements.accepts[0].maxAmountRequired == "50000"
+
+    def test_parse_402_response_flat_still_works(self, mock_eth_deps):
+        """Tests that flat (non-wrapped) 402 format still works."""
+        from swarm_provenance_uploader.core.x402_client import X402Client
+
+        client = X402Client(skip_domain_validation=True)
+        requirements = client.parse_402_response(SAMPLE_402_RESPONSE)
+
+        assert isinstance(requirements, X402PaymentRequirements)
+        assert len(requirements.accepts) == 1
+        assert requirements.accepts[0].scheme == "exact"
+
 
 class TestX402ClientSelectPaymentOption:
     """Tests for selecting payment options."""


### PR DESCRIPTION
## Summary
- Unwrap `detail` wrapper in `parse_402_response` (x402-enabled path)
- Unwrap `detail` wrapper in `_handle_402_response` (x402-disabled path)
- Both new `{"detail": {...}}` and old flat formats supported
- Version bump 0.9.2 → 0.9.3

## Test plan
- [x] 3 new unit tests covering wrapped and flat formats
- [x] All 630 unit tests pass
- [ ] Integration test against dev gateway
- [ ] Integration test against production gateway

Closes #111