### PR TITLE
Support storageRef in chain anchoring (#116)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ swarm-prov-upload chain balance                                              # W
 swarm-prov-upload chain anchor <hash>                                        # Anchor a Swarm hash on-chain
 swarm-prov-upload chain anchor <hash> --type "dataset"                       # Anchor with custom data type
 swarm-prov-upload chain anchor <hash> --owner <address>                      # Anchor as delegate for owner
+swarm-prov-upload chain anchor <hash> --storage-ref <ref>                    # Anchor with Swarm storage reference
 swarm-prov-upload chain get <hash>                                           # Get on-chain provenance record
 swarm-prov-upload chain get <hash> --follow                                  # Walk transformation chain
 swarm-prov-upload chain get <hash> --follow --depth 3                        # Limit chain walk depth
@@ -181,6 +182,8 @@ swarm-prov-upload chain protect <orig> <new> --description "..."             # C
 swarm-prov-upload chain protect <orig> <new> --anchor-new                    # Protect with auto-anchor
 swarm-prov-upload chain merge <h1> <h2> [<h3>...] <new> --description "..."  # N-to-1 merge transformation
 swarm-prov-upload chain merge <h1> <h2> <new> --type "dataset"               # Merge with custom data type
+swarm-prov-upload chain set-storage-ref <data_hash> <storage_ref>            # Set/update storage reference for anchored hash
+swarm-prov-upload chain lookup <storage_ref>                                 # Look up data hash by storage reference
 
 # Collection/manifest upload (directory as Swarm manifest, gateway only)
 swarm-prov-upload upload-collection /path/to/directory                       # Upload directory
@@ -241,10 +244,10 @@ The application follows a modular architecture with clear separation of concerns
 **ChainClient** (`core/chain_client.py`):
 - High-level facade for on-chain provenance operations
 - Wraps ChainProvider + ChainWallet + DataProvenanceContract
-- Write methods: `anchor()`, `anchor_for()`, `batch_anchor()`, `transform()`, `merge_transform()`, `access()`, `batch_access()`, `set_status()`, `transfer_ownership()`, `set_delegate()`
-- Read methods: `get()`, `verify()`, `get_provenance_chain()`, `balance()`, `health_check()`
+- Write methods: `anchor()`, `anchor_for()`, `batch_anchor()`, `transform()`, `merge_transform()`, `access()`, `batch_access()`, `set_status()`, `transfer_ownership()`, `set_delegate()`, `set_storage_ref()`
+- Read methods: `get()`, `verify()`, `get_provenance_chain()`, `get_by_storage_ref()`, `balance()`, `health_check()`
 - Lazy-loads web3 and eth-account via `blockchain` optional dependency group
-- Targets DataProvenance v2 contract on Base Sepolia (`0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a`)
+- Targets DataProvenance v4 contract on Base Sepolia (`0x3945aDfd5Df9ab2F5cB4Ca0eb3D4384CC3650322`)
 - V2 auto-detection: state-based traversal on v2 contracts, event cache fallback on v1
 - Duplicate transformation pre-checks to avoid wasting gas
 - RPC failover support via `rpc_fallbacks` parameter
@@ -275,8 +278,8 @@ The application follows a modular architecture with clear separation of concerns
 
 **Chain Models**: Schemas for on-chain provenance:
 - `DataStatusEnum`: On-chain data status (ACTIVE, RESTRICTED, DELETED)
-- `ChainProvenanceRecord`: Full on-chain provenance record
-- `AnchorResult`: Transaction result from anchoring a hash
+- `ChainProvenanceRecord`: Full on-chain provenance record (includes `storage_ref` field for Swarm storage reference)
+- `AnchorResult`: Transaction result from anchoring a hash (includes optional `storage_ref`)
 - `TransformResult`: Transaction result from recording a transformation
 - `MergeTransformResult`: Transaction result from N-to-1 merge transformation
 - `AccessResult`: Transaction result from recording data access

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ swarm-prov-upload chain balance --json
 swarm-prov-upload chain anchor <swarm_hash>
 swarm-prov-upload chain anchor <swarm_hash> --type "dataset"
 swarm-prov-upload chain anchor <swarm_hash> --owner <address>  # anchor as delegate
+swarm-prov-upload chain anchor <swarm_hash> --storage-ref <ref>  # anchor with Swarm storage reference
 swarm-prov-upload chain anchor <swarm_hash> --gas 500000      # explicit gas limit
 
 # Record data access
@@ -273,6 +274,12 @@ swarm-prov-upload chain delegate <address> --revoke
 # Equivalent to: verify ACTIVE → optionally anchor → transform → restrict
 swarm-prov-upload chain protect <original_hash> <new_hash> --description "Removed PII"
 swarm-prov-upload chain protect <orig> <new> --anchor-new --description "Redacted"  # anchor new hash first
+
+# Set or update storage reference for an anchored hash
+swarm-prov-upload chain set-storage-ref <data_hash> <storage_ref>
+
+# Look up data hash by storage reference
+swarm-prov-upload chain lookup <storage_ref>
 
 # Walk transformation chain (follow lineage)
 swarm-prov-upload chain get <hash> --follow               # full chain
@@ -321,7 +328,7 @@ print(f"TX: {result.explorer_url}")
 ```
 
 **Write operations** (require wallet + gas):
-- `anchor(swarm_hash, data_type)` - Register a hash on-chain
+- `anchor(swarm_hash, data_type, storage_ref)` - Register a hash on-chain (optional storage reference)
 - `anchor_for(swarm_hash, owner, data_type)` - Register on behalf of another owner
 - `batch_anchor(swarm_hashes, data_types)` - Batch register multiple hashes
 - `transform(original_hash, new_hash, description)` - Record data transformation
@@ -331,11 +338,13 @@ print(f"TX: {result.explorer_url}")
 - `set_status(swarm_hash, status)` - Change data status (ACTIVE/RESTRICTED/DELETED)
 - `transfer_ownership(swarm_hash, new_owner)` - Transfer data ownership
 - `set_delegate(delegate, authorized)` - Authorize/revoke a delegate
+- `set_storage_ref(swarm_hash, storage_ref)` - Set/update storage reference for anchored hash
 
 **Read operations** (no gas required):
 - `get(swarm_hash)` - Get full provenance record
 - `verify(swarm_hash)` - Check if hash is registered
 - `get_provenance_chain(swarm_hash)` - Follow transformation lineage
+- `get_by_storage_ref(storage_ref)` - Look up data hash by storage reference
 - `balance()` - Get wallet balance and chain info
 - `health_check()` - Check RPC connectivity
 
@@ -804,6 +813,8 @@ See [examples/README.md](examples/README.md) for the full guide with walkthrough
 │  │                 │  │ chain transfer   │  │                                 │ │
 │  │                 │  │ chain delegate   │  │                                 │ │
 │  │                 │  │ chain protect    │  │                                 │ │
+│  │ chain set-stor.. │  │                                 │ │
+│  │ chain lookup     │  │                                 │ │
 │  └─────────────────┘  └──────────────────┘  └─────────────────────────────────┘ │
 └─────────────────────────────────────────────────────────────────────────────────┘
                                         │
@@ -990,6 +1001,7 @@ See [examples/README.md](examples/README.md) for the full guide with walkthrough
 │  • DataProvenance smart contract  • On-chain data registration                │
 │  • Transformation lineage         • Access tracking                           │
 │  • Ownership transfer             • Delegate authorization                    │
+│  • Storage reference mapping      • Reverse lookup by storageRef             │
 │  • Base Sepolia / Base mainnet    • Lazy dependency loading                   │
 └─────────────────────────────────────────────────────────────────────────────────┘
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swarm-provenance-uploader"
-version = "0.9.3"
+version = "0.10.0"
 description = "A CLI toolkit for wrapping data and uploading to Swarm."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/swarm_provenance_uploader/__init__.py
+++ b/swarm_provenance_uploader/__init__.py
@@ -3,7 +3,7 @@
 import subprocess
 from pathlib import Path
 
-__version_base__ = "0.9.3"
+__version_base__ = "0.10.0"
 
 
 def _get_git_hash() -> str:

--- a/swarm_provenance_uploader/chain/abi/DataProvenance.json
+++ b/swarm_provenance_uploader/chain/abi/DataProvenance.json
@@ -109,13 +109,13 @@
       },
       {
         "indexed": false,
-        "internalType": "enum DataProvenance.DataStatus",
+        "internalType": "uint8",
         "name": "oldStatus",
         "type": "uint8"
       },
       {
         "indexed": false,
-        "internalType": "enum DataProvenance.DataStatus",
+        "internalType": "uint8",
         "name": "newStatus",
         "type": "uint8"
       }
@@ -221,6 +221,25 @@
       }
     ],
     "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "dataHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "storageRef",
+        "type": "bytes32"
+      }
+    ],
+    "name": "StorageRefLinked",
     "type": "event"
   },
   {
@@ -364,7 +383,30 @@
         "type": "bytes32[]"
       },
       {
-        "internalType": "enum DataProvenance.DataStatus[]",
+        "internalType": "string[]",
+        "name": "_dataTypes",
+        "type": "string[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_storageRefs",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "batchRegisterData",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "_dataHashes",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8[]",
         "name": "_statuses",
         "type": "uint8[]"
       }
@@ -418,7 +460,12 @@
         "type": "string"
       },
       {
-        "internalType": "enum DataProvenance.DataStatus",
+        "internalType": "bytes32",
+        "name": "storageRef",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint8",
         "name": "status",
         "type": "uint8"
       }
@@ -440,6 +487,25 @@
         "internalType": "bytes32[]",
         "name": "",
         "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_storageRef",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getDataHashByStorageRef",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
       }
     ],
     "stateMutability": "view",
@@ -478,6 +544,11 @@
             "type": "string"
           },
           {
+            "internalType": "bytes32",
+            "name": "storageRef",
+            "type": "bytes32"
+          },
+          {
             "components": [
               {
                 "internalType": "bytes32",
@@ -500,7 +571,7 @@
             "type": "address[]"
           },
           {
-            "internalType": "enum DataProvenance.DataStatus",
+            "internalType": "uint8",
             "name": "status",
             "type": "uint8"
           }
@@ -771,7 +842,7 @@
         "type": "bytes32"
       },
       {
-        "internalType": "enum DataProvenance.DataStatus",
+        "internalType": "uint8",
         "name": "_newStatus",
         "type": "uint8"
       }
@@ -876,9 +947,60 @@
         "type": "string"
       },
       {
+        "internalType": "bytes32",
+        "name": "_storageRef",
+        "type": "bytes32"
+      }
+    ],
+    "name": "registerData",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "_dataType",
+        "type": "string"
+      },
+      {
         "internalType": "address",
         "name": "_actualOwner",
         "type": "address"
+      }
+    ],
+    "name": "registerDataFor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "_dataType",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_actualOwner",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_storageRef",
+        "type": "bytes32"
       }
     ],
     "name": "registerDataFor",
@@ -925,7 +1047,7 @@
         "type": "bytes32"
       },
       {
-        "internalType": "enum DataProvenance.DataStatus",
+        "internalType": "uint8",
         "name": "_newStatus",
         "type": "uint8"
       }
@@ -951,6 +1073,43 @@
     "name": "setDelegate",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_storageRef",
+        "type": "bytes32"
+      }
+    ],
+    "name": "setStorageRef",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storageRefToDataHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/swarm_provenance_uploader/chain/contract.py
+++ b/swarm_provenance_uploader/chain/contract.py
@@ -181,6 +181,7 @@ class DataProvenanceContract:
         data_hash: str,
         data_type: str,
         sender: str,
+        storage_ref: Optional[str] = None,
     ) -> dict:
         """
         Build transaction to register a data hash on-chain.
@@ -189,17 +190,22 @@ class DataProvenanceContract:
             data_hash: 64-char hex hash of the data (Swarm reference).
             data_type: Category/type string (max 64 chars).
             sender: Address of the transaction sender.
+            storage_ref: Optional 64-char hex storage reference (e.g. Swarm hash).
 
         Returns:
             Unsigned transaction dict.
         """
         hash_bytes = _normalize_hash(data_hash)
         _validate_data_type(data_type)
+        tx_params = {"from": self._web3.to_checksum_address(sender)}
+        if storage_ref is not None:
+            ref_bytes = _normalize_hash(storage_ref)
+            return self._contract.functions.registerData(
+                hash_bytes, data_type, ref_bytes
+            ).build_transaction(tx_params)
         return self._contract.functions.registerData(
             hash_bytes, data_type
-        ).build_transaction({
-            "from": self._web3.to_checksum_address(sender),
-        })
+        ).build_transaction(tx_params)
 
     def build_register_data_for_tx(
         self,
@@ -207,6 +213,7 @@ class DataProvenanceContract:
         data_type: str,
         actual_owner: str,
         sender: str,
+        storage_ref: Optional[str] = None,
     ) -> dict:
         """
         Build transaction to register data on behalf of another owner.
@@ -218,25 +225,30 @@ class DataProvenanceContract:
             data_type: Category/type string (max 64 chars).
             actual_owner: Address of the actual data owner.
             sender: Address of the delegate sending the transaction.
+            storage_ref: Optional 64-char hex storage reference (e.g. Swarm hash).
 
         Returns:
             Unsigned transaction dict.
         """
         hash_bytes = _normalize_hash(data_hash)
         _validate_data_type(data_type)
+        owner_addr = self._web3.to_checksum_address(actual_owner)
+        tx_params = {"from": self._web3.to_checksum_address(sender)}
+        if storage_ref is not None:
+            ref_bytes = _normalize_hash(storage_ref)
+            return self._contract.functions.registerDataFor(
+                hash_bytes, data_type, owner_addr, ref_bytes
+            ).build_transaction(tx_params)
         return self._contract.functions.registerDataFor(
-            hash_bytes,
-            data_type,
-            self._web3.to_checksum_address(actual_owner),
-        ).build_transaction({
-            "from": self._web3.to_checksum_address(sender),
-        })
+            hash_bytes, data_type, owner_addr,
+        ).build_transaction(tx_params)
 
     def build_batch_register_data_tx(
         self,
         data_hashes: List[str],
         data_types: List[str],
         sender: str,
+        storage_refs: Optional[List[str]] = None,
     ) -> dict:
         """
         Build transaction to register multiple data hashes in one call.
@@ -245,6 +257,8 @@ class DataProvenanceContract:
             data_hashes: List of 64-char hex hashes.
             data_types: List of data type strings (same length as hashes).
             sender: Address of the transaction sender.
+            storage_refs: Optional list of 64-char hex storage references
+                (same length as hashes). Pass None to omit storage refs.
 
         Returns:
             Unsigned transaction dict.
@@ -266,11 +280,20 @@ class DataProvenanceContract:
         for dt in data_types:
             _validate_data_type(dt)
 
+        tx_params = {"from": self._web3.to_checksum_address(sender)}
+        if storage_refs is not None:
+            if len(storage_refs) != len(data_hashes):
+                raise ChainValidationError(
+                    f"storage_refs ({len(storage_refs)}) must match "
+                    f"data_hashes ({len(data_hashes)}) length"
+                )
+            ref_bytes_list = [_normalize_hash(r) for r in storage_refs]
+            return self._contract.functions.batchRegisterData(
+                hash_bytes_list, data_types, ref_bytes_list
+            ).build_transaction(tx_params)
         return self._contract.functions.batchRegisterData(
             hash_bytes_list, data_types
-        ).build_transaction({
-            "from": self._web3.to_checksum_address(sender),
-        })
+        ).build_transaction(tx_params)
 
     def build_record_transformation_tx(
         self,
@@ -460,55 +483,103 @@ class DataProvenanceContract:
             "from": self._web3.to_checksum_address(sender),
         })
 
+    def build_set_storage_ref_tx(
+        self,
+        data_hash: str,
+        storage_ref: str,
+        sender: str,
+    ) -> dict:
+        """
+        Build transaction to set the storage reference for an existing record.
+
+        This is a set-once operation — the storage ref cannot be changed after being set.
+
+        Args:
+            data_hash: 64-char hex hash of the registered data.
+            storage_ref: 64-char hex storage reference (e.g. Swarm hash).
+            sender: Address of the data owner.
+
+        Returns:
+            Unsigned transaction dict.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        ref_bytes = _normalize_hash(storage_ref)
+        return self._contract.functions.setStorageRef(
+            hash_bytes, ref_bytes
+        ).build_transaction({
+            "from": self._web3.to_checksum_address(sender),
+        })
+
     # --- Read methods (direct contract calls) ---
+
+    def get_data_hash_by_storage_ref(self, storage_ref: str) -> Optional[bytes]:
+        """
+        Reverse lookup: get the data hash associated with a storage reference.
+
+        Args:
+            storage_ref: 64-char hex storage reference.
+
+        Returns:
+            Data hash as bytes32, or None if no mapping exists.
+        """
+        ref_bytes = _normalize_hash(storage_ref)
+        result = self._contract.functions.getDataHashByStorageRef(ref_bytes).call()
+        # bytes32(0) means no mapping
+        if result == b"\x00" * 32:
+            return None
+        return result
 
     def get_data_record(self, data_hash: str) -> Tuple:
         """
         Get the full on-chain record for a data hash.
 
-        The bundled ABI uses the v2 schema (``TransformationLink[]`` /
-        ``tuple[]``).  On v1 contracts where ``getDataRecord`` returns
-        ``string[]`` for transformations, the ABI decoder will fail; we
-        fall back to ``dataRecords()`` (scalar fields, no arrays).
+        The bundled ABI uses the v4 schema which includes ``storageRef``
+        and ``TransformationLink[]``.  On older contracts the ABI decoder
+        may fail; we fall back to ``dataRecords()`` (scalar fields only).
 
         Args:
             data_hash: 64-char hex hash.
 
         Returns:
-            Tuple of (dataHash, owner, timestamp, dataType,
-                       transformations, accessors, status).
+            Tuple of (dataHash, owner, timestamp, dataType, storageRef,
+                       transformationLinks, accessors, status).
 
-            On v1 contracts, field 4 (transformations) is ``string[]``.
-            On v2 contracts, field 4 is ``TransformationLink[]``
+            On v4 contracts, storageRef is ``bytes32`` and
+            transformationLinks is ``TransformationLink[]``
             (list of tuples ``(bytes32, string)``).
+            On older contracts the fallback returns bytes32(0) for
+            storageRef and empty lists for arrays.
         """
         hash_bytes = _normalize_hash(data_hash)
         try:
             return self._contract.functions.getDataRecord(hash_bytes).call()
         except (OverflowError, Exception) as e:
-            # V1 contracts return string[] for transformations but the ABI
-            # declares tuple[] (v2), causing a decode error.  Reconstruct
-            # the record from the scalar mapping.
+            # Older contracts may not match the v4 ABI layout.
+            # Reconstruct the record from the scalar mapping.
             if self.supports_transformation_links():
-                raise  # genuine error on v2 — re-raise
-            logger.debug("getDataRecord decode failed on v1, using fallback: %s", e)
+                raise  # genuine error on v2+ — re-raise
+            logger.debug("getDataRecord decode failed on older contract, using fallback: %s", e)
             return self._get_data_record_v1_fallback(hash_bytes)
 
     def _get_data_record_v1_fallback(self, hash_bytes: bytes) -> Tuple:
-        """Reconstruct getDataRecord result for v1 contracts.
+        """Reconstruct getDataRecord result for older contracts.
 
-        The v2 ABI expects ``TransformationLink[]`` tuples but v1
-        contracts return ``string[]``, causing a decode error.  Falls
-        back to ``dataRecords()`` (scalar fields only — no arrays).
-        Accessors and transformations are returned as empty lists; callers
-        can still get transformations from ``DataTransformed`` events.
+        The v4 ABI expects 8 fields but older contracts return fewer.
+        Falls back to ``dataRecords()`` (scalar fields only — no arrays).
+        Accessors and transformations are returned as empty lists; storageRef
+        as zero bytes.
         """
-        # dataRecords returns: (dataHash, owner, timestamp, dataType, status)
+        # dataRecords on v4 returns: (dataHash, owner, timestamp, dataType, storageRef, status)
+        # On older contracts it returns: (dataHash, owner, timestamp, dataType, status)
         basic = self._contract.functions.dataRecords(hash_bytes).call()
-        data_hash, owner, timestamp, data_type, status = basic
+        if len(basic) == 6:
+            data_hash, owner, timestamp, data_type, storage_ref, status = basic
+        else:
+            data_hash, owner, timestamp, data_type, status = basic
+            storage_ref = b"\x00" * 32
 
-        # Return the same 7-element tuple shape as getDataRecord
-        return (data_hash, owner, timestamp, data_type, [], [], status)
+        # Return the same 8-element tuple shape as v4 getDataRecord
+        return (data_hash, owner, timestamp, data_type, storage_ref, [], [], status)
 
     def get_user_data_records(self, user: str) -> List[bytes]:
         """

--- a/swarm_provenance_uploader/chain/provider.py
+++ b/swarm_provenance_uploader/chain/provider.py
@@ -39,8 +39,8 @@ CHAIN_PRESETS = {
         "chain_id": 84532,
         "rpc_url": "https://sepolia.base.org",
         "explorer_url": "https://base-sepolia.blockscout.com",
-        "contract_address": "0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a",
-        "deploy_block": 39_075_766,
+        "contract_address": "0x3945aDfd5Df9ab2F5cB4Ca0eb3D4384CC3650322",
+        "deploy_block": 39_905_249,
         "rpc_fallbacks": [
             "https://base-sepolia-rpc.publicnode.com",
             "https://base-sepolia.drpc.org",

--- a/swarm_provenance_uploader/cli.py
+++ b/swarm_provenance_uploader/cli.py
@@ -1838,6 +1838,9 @@ def chain_get(
             typer.echo(f"\n\u250c\u2500\u2500\u2500 [{i}] {label} \u2500\u2500\u2500")
             typer.echo(f"\u2502  Hash:   {hash_short}")
             typer.echo(f"\u2502  Type:   {record.data_type}")
+            if record.storage_ref:
+                ref_short = f"{record.storage_ref[:12]}...{record.storage_ref[-8:]}" if len(record.storage_ref) > 20 else record.storage_ref
+                typer.echo(f"\u2502  Storage: {ref_short}")
             typer.echo(f"\u2502  Owner:  {owner_short}")
             typer.echo(f"\u2502  Status: {record.status.name}")
 
@@ -1884,6 +1887,9 @@ def chain_get(
     typer.echo(f"  Hash:    {hash_short}")
     typer.echo(f"  Owner:   {owner_short}")
     typer.echo(f"  Type:    {record.data_type}")
+    if record.storage_ref:
+        ref_short = f"{record.storage_ref[:12]}...{record.storage_ref[-8:]}" if len(record.storage_ref) > 20 else record.storage_ref
+        typer.echo(f"  Storage: {ref_short}")
     typer.echo(f"  Status:  {record.status.name}")
     typer.echo(f"  Time:    {ts_str}")
 
@@ -1907,6 +1913,7 @@ def chain_get(
 def chain_anchor(
     swarm_hash: Annotated[str, typer.Argument(help="Swarm reference hash to anchor on-chain.")],
     data_type: Annotated[str, typer.Option("--type", "-t", help="Data type/category.")] = "swarm-provenance",
+    storage_ref: Annotated[Optional[str], typer.Option("--storage-ref", "-s", help="Storage reference (e.g. Swarm hash) to link bidirectionally.")] = None,
     owner: Annotated[Optional[str], typer.Option("--owner", help="Register on behalf of this owner address (requires delegate authorization).")] = None,
     gas: Annotated[Optional[int], typer.Option("--gas", help="Explicit gas limit (skips estimation).")] = None,
     verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable verbose output.")] = False,
@@ -1915,6 +1922,7 @@ def chain_anchor(
     """
     Anchor a Swarm hash on-chain by registering it in the DataProvenance contract.
 
+    Use --storage-ref to link a Swarm storage reference for bidirectional lookup.
     Use --owner to register on behalf of another address (caller must be authorized delegate).
     """
     if gas is not None:
@@ -1922,9 +1930,9 @@ def chain_anchor(
     try:
         client = _get_chain_client(verbose=verbose)
         if owner:
-            result = client.anchor_for(swarm_hash, owner=owner, data_type=data_type, verbose=verbose)
+            result = client.anchor_for(swarm_hash, owner=owner, data_type=data_type, storage_ref=storage_ref, verbose=verbose)
         else:
-            result = client.anchor(swarm_hash, data_type=data_type, verbose=verbose)
+            result = client.anchor(swarm_hash, data_type=data_type, storage_ref=storage_ref, verbose=verbose)
     except typer.Exit:
         raise
     except exceptions.DataAlreadyRegisteredError as e:
@@ -1969,6 +1977,8 @@ def chain_anchor(
     typer.secho(f"\nAnchored successfully!", fg=typer.colors.GREEN, bold=True)
     typer.echo(f"  Hash:    {swarm_hash}")
     typer.echo(f"  Type:    {data_type}")
+    if storage_ref:
+        typer.echo(f"  Storage: {storage_ref}")
     if owner:
         typer.echo(f"  Owner:   {owner}")
     typer.echo(f"  Tx:      {result.tx_hash}")
@@ -1976,6 +1986,104 @@ def chain_anchor(
     typer.echo(f"  Gas:     {result.gas_used}")
     if result.explorer_url:
         typer.echo(f"  Explorer: {result.explorer_url}")
+
+
+@chain_app.command("set-storage-ref")
+def chain_set_storage_ref(
+    data_hash: Annotated[str, typer.Argument(help="Registered data hash.")],
+    storage_ref: Annotated[str, typer.Argument(help="Storage reference (e.g. Swarm hash) to link.")],
+    gas: Annotated[Optional[int], typer.Option("--gas", help="Explicit gas limit.")] = None,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable verbose output.")] = False,
+    output_json: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
+):
+    """
+    Set the storage reference for an existing on-chain record (set-once, immutable).
+
+    Links a Swarm storage hash to a registered data hash for bidirectional lookup.
+    """
+    if gas is not None:
+        _chain_config["gas_limit"] = gas
+    try:
+        client = _get_chain_client(verbose=verbose)
+        result = client.set_storage_ref(data_hash, storage_ref, verbose=verbose)
+    except typer.Exit:
+        raise
+    except exceptions.InsufficientFundsError as e:
+        _handle_insufficient_funds(e, output_json=output_json)
+        raise typer.Exit(code=1)
+    except exceptions.ChainTransactionError as e:
+        typer.secho(f"ERROR: Transaction failed: {e}", fg=typer.colors.RED, err=True)
+        if e.tx_hash:
+            typer.echo(f"  Transaction: {e.tx_hash}")
+        raise typer.Exit(code=1)
+    except exceptions.ChainConnectionError as e:
+        typer.secho(f"ERROR: Cannot connect to chain: {e}", fg=typer.colors.RED, err=True)
+        if e.rpc_url:
+            typer.echo(f"  RPC URL: {e.rpc_url}")
+        raise typer.Exit(code=1)
+    except exceptions.ChainError as e:
+        typer.secho(f"ERROR: {e}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1)
+
+    if output_json:
+        typer.echo(json.dumps(result.model_dump(), indent=2))
+        return
+
+    typer.secho(f"\nStorage reference linked!", fg=typer.colors.GREEN, bold=True)
+    typer.echo(f"  Data:    {data_hash}")
+    typer.echo(f"  Storage: {storage_ref}")
+    typer.echo(f"  Tx:      {result.tx_hash}")
+    typer.echo(f"  Block:   {result.block_number}")
+    typer.echo(f"  Gas:     {result.gas_used}")
+    if result.explorer_url:
+        typer.echo(f"  Explorer: {result.explorer_url}")
+
+
+@chain_app.command("lookup")
+def chain_lookup(
+    storage_ref: Annotated[str, typer.Argument(help="Storage reference (e.g. Swarm hash) to look up.")],
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable verbose output.")] = False,
+    output_json: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
+):
+    """
+    Look up a provenance record by its storage reference (reverse lookup).
+    """
+    try:
+        client = _get_chain_client(verbose=verbose)
+        record = client.get_by_storage_ref(storage_ref, verbose=verbose)
+    except typer.Exit:
+        raise
+    except exceptions.DataNotRegisteredError:
+        typer.secho(f"Not found: no record linked to storage ref {storage_ref}.", fg=typer.colors.YELLOW)
+        raise typer.Exit(code=1)
+    except exceptions.ChainConnectionError as e:
+        typer.secho(f"ERROR: Cannot connect to chain: {e}", fg=typer.colors.RED, err=True)
+        if e.rpc_url:
+            typer.echo(f"  RPC URL: {e.rpc_url}")
+        raise typer.Exit(code=1)
+    except exceptions.ChainError as e:
+        typer.secho(f"ERROR: {e}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1)
+
+    if output_json:
+        typer.echo(json.dumps(record.model_dump(), indent=2))
+        return
+
+    from datetime import datetime, timezone
+    ts_str = datetime.fromtimestamp(record.timestamp, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    hash_short = f"{record.data_hash[:12]}...{record.data_hash[-8:]}" if len(record.data_hash) > 20 else record.data_hash
+    owner_short = f"{record.owner[:10]}...{record.owner[-4:]}" if len(record.owner) > 14 else record.owner
+
+    typer.echo(f"\nProvenance Record (via storage ref):")
+    typer.echo("-" * 50)
+    typer.echo(f"  Hash:    {hash_short}")
+    typer.echo(f"  Owner:   {owner_short}")
+    typer.echo(f"  Type:    {record.data_type}")
+    if record.storage_ref:
+        ref_short = f"{record.storage_ref[:12]}...{record.storage_ref[-8:]}" if len(record.storage_ref) > 20 else record.storage_ref
+        typer.echo(f"  Storage: {ref_short}")
+    typer.echo(f"  Status:  {record.status.name}")
+    typer.echo(f"  Time:    {ts_str}")
 
 
 @chain_app.command("access")

--- a/swarm_provenance_uploader/core/chain_client.py
+++ b/swarm_provenance_uploader/core/chain_client.py
@@ -256,6 +256,7 @@ class ChainClient:
         self,
         swarm_hash: str,
         data_type: str = "swarm-provenance",
+        storage_ref: Optional[str] = None,
         verbose: bool = False,
     ) -> AnchorResult:
         """
@@ -264,12 +265,14 @@ class ChainClient:
         Args:
             swarm_hash: Swarm reference hash (64 hex chars).
             data_type: Data type/category (max 64 chars, default 'swarm-provenance').
+            storage_ref: Optional storage reference (e.g. Swarm hash) to link
+                bidirectionally with the data hash.
             verbose: Enable debug output.
 
         Returns:
             AnchorResult with transaction details.
         """
-        logger.debug("Anchor: hash=%s type=%s", swarm_hash, data_type)
+        logger.debug("Anchor: hash=%s type=%s storage_ref=%s", swarm_hash, data_type, storage_ref)
 
         # Pre-check: avoid wasting gas on already-registered hashes
         try:
@@ -288,6 +291,7 @@ class ChainClient:
             data_hash=swarm_hash,
             data_type=data_type,
             sender=self._wallet.address,
+            storage_ref=storage_ref,
         )
         try:
             receipt = self._send_transaction(tx, verbose=verbose)
@@ -316,6 +320,7 @@ class ChainClient:
             swarm_hash=swarm_hash,
             data_type=data_type,
             owner=self._wallet.address,
+            storage_ref=storage_ref,
         )
 
     def anchor_for(
@@ -323,6 +328,7 @@ class ChainClient:
         swarm_hash: str,
         owner: str,
         data_type: str = "swarm-provenance",
+        storage_ref: Optional[str] = None,
         verbose: bool = False,
     ) -> AnchorResult:
         """
@@ -334,6 +340,7 @@ class ChainClient:
             swarm_hash: Swarm reference hash.
             owner: Address of the actual data owner.
             data_type: Data type/category.
+            storage_ref: Optional storage reference to link with the data hash.
             verbose: Enable debug output.
 
         Returns:
@@ -359,6 +366,7 @@ class ChainClient:
             data_type=data_type,
             actual_owner=owner,
             sender=self._wallet.address,
+            storage_ref=storage_ref,
         )
         receipt = self._send_transaction(tx, verbose=verbose)
 
@@ -370,12 +378,14 @@ class ChainClient:
             swarm_hash=swarm_hash,
             data_type=data_type,
             owner=owner,
+            storage_ref=storage_ref,
         )
 
     def batch_anchor(
         self,
         swarm_hashes: List[str],
         data_types: List[str],
+        storage_refs: Optional[List[str]] = None,
         verbose: bool = False,
     ) -> AnchorResult:
         """
@@ -384,6 +394,7 @@ class ChainClient:
         Args:
             swarm_hashes: List of Swarm reference hashes.
             data_types: List of data type strings (same length).
+            storage_refs: Optional list of storage references (same length).
             verbose: Enable debug output.
 
         Returns:
@@ -395,6 +406,7 @@ class ChainClient:
             data_hashes=swarm_hashes,
             data_types=data_types,
             sender=self._wallet.address,
+            storage_refs=storage_refs,
         )
         receipt = self._send_transaction(tx, verbose=verbose)
 
@@ -407,6 +419,73 @@ class ChainClient:
             data_type=data_types[0] if data_types else "",
             owner=self._wallet.address,
         )
+
+    def set_storage_ref(
+        self,
+        data_hash: str,
+        storage_ref: str,
+        verbose: bool = False,
+    ) -> AnchorResult:
+        """
+        Set the storage reference for an existing on-chain record.
+
+        This is a set-once operation — once set, the storage ref is immutable.
+
+        Args:
+            data_hash: Registered data hash (64 hex chars).
+            storage_ref: Storage reference to link (e.g. Swarm hash, 64 hex chars).
+            verbose: Enable debug output.
+
+        Returns:
+            AnchorResult with transaction details.
+        """
+        logger.debug("Set storage ref: hash=%s ref=%s", data_hash, storage_ref)
+
+        tx = self._contract.build_set_storage_ref_tx(
+            data_hash=data_hash,
+            storage_ref=storage_ref,
+            sender=self._wallet.address,
+        )
+        receipt = self._send_transaction(tx, verbose=verbose)
+
+        return AnchorResult(
+            tx_hash=receipt["transactionHash"].hex(),
+            block_number=receipt["blockNumber"],
+            gas_used=receipt["gasUsed"],
+            explorer_url=self._receipt_to_explorer_url(receipt),
+            swarm_hash=data_hash,
+            data_type="",
+            owner=self._wallet.address,
+            storage_ref=storage_ref,
+        )
+
+    def get_by_storage_ref(
+        self,
+        storage_ref: str,
+        verbose: bool = False,
+    ) -> ChainProvenanceRecord:
+        """
+        Look up a provenance record by its storage reference.
+
+        Args:
+            storage_ref: Storage reference hash (64 hex chars).
+            verbose: Enable debug output.
+
+        Returns:
+            ChainProvenanceRecord for the linked data hash.
+
+        Raises:
+            DataNotRegisteredError: If no record is linked to this storage ref.
+        """
+        logger.debug("Lookup by storage ref: %s", storage_ref)
+        data_hash_bytes = self._contract.get_data_hash_by_storage_ref(storage_ref)
+        if data_hash_bytes is None:
+            raise DataNotRegisteredError(
+                f"No data record linked to storage ref {storage_ref}",
+                data_hash=storage_ref,
+            )
+        data_hash = data_hash_bytes.hex()
+        return self.get(data_hash, verbose=verbose)
 
     def transform(
         self,
@@ -787,12 +866,13 @@ class ChainClient:
         record = self._contract.get_data_record(swarm_hash)
 
         # record is a tuple: (dataHash, owner, timestamp, dataType,
-        #                      transformations, accessors, status)
+        #                      storageRef, transformationLinks, accessors, status)
         (
             data_hash_bytes,
             owner,
             timestamp,
             data_type,
+            storage_ref_bytes,
             transformations,
             accessors,
             status,
@@ -806,12 +886,17 @@ class ChainClient:
                 data_hash=swarm_hash,
             )
 
-        # Parse transformations — v2 contracts return TransformationLink[]
+        # Parse storage ref — bytes32(0) means not set
+        storage_ref = None
+        if isinstance(storage_ref_bytes, bytes) and storage_ref_bytes != b"\x00" * 32:
+            storage_ref = storage_ref_bytes.hex()
+
+        # Parse transformations — v2+ contracts return TransformationLink[]
         # (list of (bytes32, string) tuples), v1 returns string[].
         chain_transformations = []
         for t in transformations:
             if isinstance(t, (tuple, list)) and len(t) >= 2:
-                # V2 contract: TransformationLink(newDataHash, description)
+                # V2+ contract: TransformationLink(newDataHash, description)
                 new_hash = t[0].hex() if isinstance(t[0], bytes) else str(t[0])
                 chain_transformations.append(
                     ChainTransformation(description=str(t[1]), new_data_hash=new_hash)
@@ -821,11 +906,12 @@ class ChainClient:
                 chain_transformations.append(ChainTransformation(description=str(t)))
 
         logger.debug(
-            "Record: owner=%s type=%s status=%s accessors=%d",
+            "Record: owner=%s type=%s status=%s accessors=%d storage_ref=%s",
             owner,
             data_type,
             DataStatus(status).name,
             len(accessors),
+            storage_ref,
         )
 
         if verbose:
@@ -833,6 +919,8 @@ class ChainClient:
             print(f"DEBUG: Type: {data_type}")
             print(f"DEBUG: Status: {DataStatus(status).name}")
             print(f"DEBUG: Accessors: {len(accessors)}")
+            if storage_ref:
+                print(f"DEBUG: Storage Ref: {storage_ref}")
 
         return ChainProvenanceRecord(
             data_hash=(
@@ -843,6 +931,7 @@ class ChainClient:
             owner=owner,
             timestamp=timestamp,
             data_type=data_type,
+            storage_ref=storage_ref,
             status=DataStatusEnum(status),
             accessors=list(accessors),
             transformations=chain_transformations,

--- a/swarm_provenance_uploader/models.py
+++ b/swarm_provenance_uploader/models.py
@@ -264,6 +264,7 @@ class ChainProvenanceRecord(BaseModel):
     owner: str = Field(description="Ethereum address of data owner")
     timestamp: int = Field(description="Unix timestamp when registered")
     data_type: str = Field(description="Type/category of the data")
+    storage_ref: Optional[str] = Field(default=None, description="Storage reference (e.g. Swarm hash)")
     status: DataStatusEnum = Field(description="Current data status")
     accessors: List[str] = Field(default_factory=list, description="Addresses that accessed this data")
     transformations: List[ChainTransformation] = Field(
@@ -280,6 +281,7 @@ class AnchorResult(BaseModel):
     swarm_hash: str = Field(description="The anchored Swarm reference hash")
     data_type: str = Field(description="Data type registered on-chain")
     owner: str = Field(description="Owner address of the registered data")
+    storage_ref: Optional[str] = Field(default=None, description="Storage reference linked during anchoring")
 
 
 class TransformResult(BaseModel):

--- a/tests/test_chain_client.py
+++ b/tests/test_chain_client.py
@@ -31,7 +31,7 @@ DUMMY_PRIVATE_KEY = "0x" + "a" * 64
 DUMMY_ADDRESS = "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00"
 DUMMY_HASH = "a" * 64
 DUMMY_HASH_BYTES = bytes.fromhex(DUMMY_HASH)
-DUMMY_CONTRACT = "0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a"
+DUMMY_CONTRACT = "0x3945aDfd5Df9ab2F5cB4Ca0eb3D4384CC3650322"
 DUMMY_TX_HASH_BYTES = bytes.fromhex("bb" * 32)
 ZERO_ADDRESS = "0x" + "0" * 40
 
@@ -124,16 +124,24 @@ def mock_chain_deps():
             "data": "0x",
         }
 
+        mock_contract.functions.setStorageRef.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+
         # Mock read functions
         mock_contract.functions.getDataRecord.return_value.call.return_value = (
             DUMMY_HASH_BYTES,  # dataHash
             DUMMY_ADDRESS,     # owner
             1700000000,        # timestamp
             "swarm-provenance",  # dataType
-            [],                # transformations
+            b"\x00" * 32,     # storageRef (not set)
+            [],                # transformationLinks
             [],                # accessors
             0,                 # status (ACTIVE)
         )
+        mock_contract.functions.getDataHashByStorageRef.return_value.call.return_value = b"\x00" * 32
         mock_contract.functions.getUserDataRecords.return_value.call.return_value = [
             DUMMY_HASH_BYTES,
         ]
@@ -363,7 +371,7 @@ class TestChainProvider:
 
         assert provider.chain == "base-sepolia"
         assert provider.chain_id == 84532
-        assert provider.contract_address == "0xD4a724CD7f5C4458cD2d884C2af6f011aC3Af80a"
+        assert provider.contract_address == "0x3945aDfd5Df9ab2F5cB4Ca0eb3D4384CC3650322"
 
     def test_custom_rpc_url(self, mock_chain_deps):
         """Tests that custom RPC URL is used."""
@@ -556,7 +564,7 @@ class TestChainClientInit:
 
         # Pre-check expects unregistered hash
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
         )
 
         client = ChainClient(
@@ -590,7 +598,7 @@ class TestChainClientAnchor:
 
         # Pre-check expects unregistered hash (zero-address owner)
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
         )
 
         client = ChainClient(chain="base-sepolia")
@@ -610,7 +618,7 @@ class TestChainClientAnchor:
 
         # Pre-check expects unregistered hash
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
         )
 
         client = ChainClient(chain="base-sepolia")
@@ -624,7 +632,7 @@ class TestChainClientAnchor:
 
         # Pre-check expects unregistered hash
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
         )
 
         other_owner = "0x1111111111111111111111111111111111111111"
@@ -651,6 +659,37 @@ class TestChainClientAnchor:
         assert isinstance(result, AnchorResult)
         assert result.swarm_hash == DUMMY_HASH
 
+    def test_anchor_with_storage_ref(self, mock_chain_deps):
+        """Tests anchoring with a storage reference."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        # Pre-check expects unregistered hash
+        mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
+        )
+
+        storage_ref = "cc" * 32
+        client = ChainClient(chain="base-sepolia")
+        result = client.anchor(swarm_hash=DUMMY_HASH, storage_ref=storage_ref)
+
+        assert isinstance(result, AnchorResult)
+        assert result.storage_ref == storage_ref
+        assert result.swarm_hash == DUMMY_HASH
+
+    def test_anchor_without_storage_ref(self, mock_chain_deps):
+        """Tests that anchor without storage_ref returns None for that field."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        # Pre-check expects unregistered hash
+        mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        result = client.anchor(swarm_hash=DUMMY_HASH)
+
+        assert result.storage_ref is None
+
     def test_anchor_invalid_hash(self, mock_chain_deps):
         """Tests that invalid hash raises validation error."""
         from swarm_provenance_uploader.core.chain_client import ChainClient
@@ -658,6 +697,54 @@ class TestChainClientAnchor:
         client = ChainClient(chain="base-sepolia")
         with pytest.raises(ChainValidationError):
             client.anchor(swarm_hash="tooshort")
+
+
+class TestChainClientStorageRef:
+    """Tests for storage reference operations."""
+
+    def test_set_storage_ref_success(self, mock_chain_deps):
+        """Tests setting a storage reference on an existing record."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        storage_ref = "dd" * 32
+        client = ChainClient(chain="base-sepolia")
+        result = client.set_storage_ref(data_hash=DUMMY_HASH, storage_ref=storage_ref)
+
+        assert isinstance(result, AnchorResult)
+        assert result.storage_ref == storage_ref
+        assert result.swarm_hash == DUMMY_HASH
+
+    def test_get_by_storage_ref_success(self, mock_chain_deps):
+        """Tests looking up a record by storage reference."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        storage_ref = "ee" * 32
+        # Reverse lookup returns data hash
+        mock_chain_deps["contract"].functions.getDataHashByStorageRef.return_value.call.return_value = DUMMY_HASH_BYTES
+
+        # getDataRecord returns record with the storage ref
+        mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES, DUMMY_ADDRESS, 1700000000, "swarm-provenance",
+            bytes.fromhex(storage_ref), [], [], 0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        record = client.get_by_storage_ref(storage_ref)
+
+        assert isinstance(record, ChainProvenanceRecord)
+        assert record.data_hash == DUMMY_HASH
+        assert record.storage_ref == storage_ref
+
+    def test_get_by_storage_ref_not_found(self, mock_chain_deps):
+        """Tests that unknown storage ref raises DataNotRegisteredError."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        # Reverse lookup returns zero hash (not found)
+        mock_chain_deps["contract"].functions.getDataHashByStorageRef.return_value.call.return_value = b"\x00" * 32
+
+        client = ChainClient(chain="base-sepolia")
+        with pytest.raises(DataNotRegisteredError):
+            client.get_by_storage_ref("ff" * 32)
 
 
 class TestChainClientAlreadyRegistered:
@@ -669,7 +756,7 @@ class TestChainClientAlreadyRegistered:
 
         # Default mock returns a registered record (owner=DUMMY_ADDRESS)
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, DUMMY_ADDRESS, 1700000000, "swarm-provenance", [], [], 0,
+            DUMMY_HASH_BYTES, DUMMY_ADDRESS, 1700000000, "swarm-provenance", b"\x00" * 32, [], [], 0,
         )
 
         client = ChainClient(chain="base-sepolia")
@@ -685,7 +772,7 @@ class TestChainClientAlreadyRegistered:
         from swarm_provenance_uploader.core.chain_client import ChainClient
 
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, DUMMY_ADDRESS, 1700000000, "swarm-provenance", [], [], 0,
+            DUMMY_HASH_BYTES, DUMMY_ADDRESS, 1700000000, "swarm-provenance", b"\x00" * 32, [], [], 0,
         )
 
         other_owner = "0x1111111111111111111111111111111111111111"
@@ -700,7 +787,7 @@ class TestChainClientAlreadyRegistered:
 
         # Return zero-address owner = not registered
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
         )
 
         client = ChainClient(chain="base-sepolia")
@@ -819,6 +906,7 @@ class TestChainClientRead:
             ZERO_ADDRESS,
             0,
             "",
+            b"\x00" * 32,
             [],
             [],
             0,
@@ -845,6 +933,7 @@ class TestChainClientRead:
             ZERO_ADDRESS,
             0,
             "",
+            b"\x00" * 32,
             [],
             [],
             0,
@@ -852,6 +941,36 @@ class TestChainClientRead:
 
         client = ChainClient(chain="base-sepolia")
         assert client.verify(swarm_hash=DUMMY_HASH) is False
+
+    def test_get_record_with_storage_ref(self, mock_chain_deps):
+        """Tests that storage_ref is parsed from on-chain record."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        storage_ref = bytes.fromhex("bb" * 32)
+        mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            DUMMY_ADDRESS,
+            1700000000,
+            "swarm-provenance",
+            storage_ref,
+            [],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        record = client.get(swarm_hash=DUMMY_HASH)
+
+        assert record.storage_ref == "bb" * 32
+
+    def test_get_record_without_storage_ref(self, mock_chain_deps):
+        """Tests that zero storage_ref is returned as None."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+
+        client = ChainClient(chain="base-sepolia")
+        record = client.get(swarm_hash=DUMMY_HASH)
+
+        assert record.storage_ref is None
 
     def test_balance_info(self, mock_chain_deps):
         """Tests getting wallet balance info."""
@@ -883,7 +1002,7 @@ class TestChainClientTransaction:
 
         # Pre-check expects unregistered hash
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
         )
 
         # Make receipt indicate failure
@@ -905,7 +1024,7 @@ class TestChainClientTransaction:
 
         # Pre-check expects unregistered hash
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
         )
 
         client = ChainClient(chain="base-sepolia", gas_limit_multiplier=1.5)
@@ -927,7 +1046,7 @@ class TestChainClientGasLimit:
 
         # Pre-check expects unregistered hash
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
         )
 
         client = ChainClient(chain="base-sepolia", gas_limit=500_000)
@@ -947,7 +1066,7 @@ class TestChainClientGasLimit:
 
         # Pre-check expects unregistered hash
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
         )
 
         # Even with 2x multiplier, explicit value should be used as-is
@@ -964,7 +1083,7 @@ class TestChainClientGasLimit:
 
         # Pre-check expects unregistered hash
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
         )
 
         client = ChainClient(chain="base-sepolia", gas_limit=None)
@@ -996,6 +1115,7 @@ class TestChainClientProvenanceChain:
             ZERO_ADDRESS,
             0,
             "",
+            b"\x00" * 32,
             [],
             [],
             0,
@@ -1016,7 +1136,7 @@ class TestChainClientProvenanceChain:
         # Contract returns transformations as string[] (descriptions only)
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
             hash_a_bytes, DUMMY_ADDRESS, 1700000000, "swarm-provenance",
-            ["filtered PII", "anonymized"],
+            b"\x00" * 32, ["filtered PII", "anonymized"],
             [], 0,
         )
 
@@ -1051,7 +1171,7 @@ class TestChainClientProvenanceChain:
 
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
             hash_a_bytes, DUMMY_ADDRESS, 1700000000, "swarm-provenance",
-            ["filtered"],
+            b"\x00" * 32, ["filtered"],
             [], 0,
         )
 
@@ -1075,11 +1195,11 @@ class TestChainClientProvenanceChain:
             if data_hash == hash_a_bytes:
                 mock_call.call.return_value = (
                     hash_a_bytes, DUMMY_ADDRESS, 1700000000, "swarm-provenance",
-                    [], [], 0,
+                    b"\x00" * 32, [], [], 0,
                 )
             else:
                 mock_call.call.return_value = (
-                    data_hash, ZERO_ADDRESS, 0, "", [], [], 0,
+                    data_hash, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
                 )
             return mock_call
 
@@ -1102,7 +1222,7 @@ class TestChainClientProvenanceChain:
             mock_call = MagicMock()
             mock_call.call.return_value = (
                 hash_a_bytes, DUMMY_ADDRESS, 1700000000, "swarm-provenance",
-                [], [], 0,
+                b"\x00" * 32, [], [], 0,
             )
             return mock_call
 
@@ -1210,6 +1330,7 @@ class TestTransformationParsing:
             DUMMY_ADDRESS,
             1700000000,
             "swarm-provenance",
+            b"\x00" * 32,
             ["encrypted: AES-256-GCM"],
             [DUMMY_ADDRESS],
             0,
@@ -1231,6 +1352,7 @@ class TestTransformationParsing:
             DUMMY_ADDRESS,
             1700000000,
             "swarm-provenance",
+            b"\x00" * 32,
             ["filtered PII", "anonymized"],
             [],
             0,
@@ -1253,6 +1375,7 @@ class TestTransformationParsing:
             DUMMY_ADDRESS,
             1700000000,
             "swarm-provenance",
+            b"\x00" * 32,
             [],
             [DUMMY_ADDRESS, accessor_addr],
             0,
@@ -1604,12 +1727,12 @@ class TestAnchorRevertDetection:
             if call_count[0] == 1:
                 # First call (pre-check): not registered
                 mock_call.call.return_value = (
-                    DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+                    DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
                 )
             else:
                 # Second call (after revert): now registered
                 mock_call.call.return_value = (
-                    DUMMY_HASH_BYTES, DUMMY_ADDRESS, 1700000000, "swarm-provenance", [], [], 0,
+                    DUMMY_HASH_BYTES, DUMMY_ADDRESS, 1700000000, "swarm-provenance", b"\x00" * 32, [], [], 0,
                 )
             return mock_call
 
@@ -1641,6 +1764,7 @@ class TestV2TransformationParsing:
             DUMMY_ADDRESS,
             1700000000,
             "swarm-provenance",
+            b"\x00" * 32,
             [(new_hash_bytes, "filtered PII")],  # v2 tuple format
             [],
             0,
@@ -1662,6 +1786,7 @@ class TestV2TransformationParsing:
             DUMMY_ADDRESS,
             1700000000,
             "swarm-provenance",
+            b"\x00" * 32,
             ["plain string description"],  # v1 format
             [],
             0,
@@ -1679,14 +1804,14 @@ class TestV1Fallback:
     """Tests for v1 fallback when getDataRecord decode fails."""
 
     def test_get_data_record_v1_fallback(self, mock_chain_deps):
-        """Tests fallback to dataRecords() when v2 ABI decode fails on v1."""
+        """Tests fallback to dataRecords() when v4 ABI decode fails on v1."""
         from swarm_provenance_uploader.chain.contract import DataProvenanceContract
 
-        # getDataRecord fails (v2 ABI decode error on v1 contract)
+        # getDataRecord fails (v4 ABI decode error on v1 contract)
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.side_effect = OverflowError("decode")
         # getTransformationLinks also fails (v1 contract)
         mock_chain_deps["contract"].functions.getTransformationLinks.return_value.call.side_effect = Exception("revert")
-        # dataRecords returns scalar-only tuple
+        # dataRecords returns scalar-only tuple (v1: 5 fields, no storageRef)
         mock_chain_deps["contract"].functions.dataRecords.return_value.call.return_value = (
             DUMMY_HASH_BYTES, DUMMY_ADDRESS, 1700000000, "swarm-provenance", 0
         )
@@ -1697,11 +1822,34 @@ class TestV1Fallback:
         )
         record = contract.get_data_record(DUMMY_HASH)
 
-        # Should return 7-element tuple with empty arrays for transformations/accessors
+        # Should return 8-element tuple with zero storageRef and empty arrays
         assert record[0] == DUMMY_HASH_BYTES
         assert record[1] == DUMMY_ADDRESS
-        assert record[4] == []  # transformations (empty)
-        assert record[5] == []  # accessors (empty)
+        assert record[4] == b"\x00" * 32  # storageRef (zero)
+        assert record[5] == []  # transformations (empty)
+        assert record[6] == []  # accessors (empty)
+
+    def test_get_data_record_v4_fallback_with_storage_ref(self, mock_chain_deps):
+        """Tests fallback to dataRecords() on v4 contract (6-field tuple with storageRef)."""
+        from swarm_provenance_uploader.chain.contract import DataProvenanceContract
+
+        storage_ref = bytes.fromhex("bb" * 32)
+        mock_chain_deps["contract"].functions.getDataRecord.return_value.call.side_effect = OverflowError("decode")
+        mock_chain_deps["contract"].functions.getTransformationLinks.return_value.call.side_effect = Exception("revert")
+        # dataRecords on v4 returns 6 fields including storageRef
+        mock_chain_deps["contract"].functions.dataRecords.return_value.call.return_value = (
+            DUMMY_HASH_BYTES, DUMMY_ADDRESS, 1700000000, "swarm-provenance", storage_ref, 0
+        )
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+        record = contract.get_data_record(DUMMY_HASH)
+
+        assert record[4] == storage_ref  # storageRef preserved
+        assert record[5] == []  # transformations (empty)
+        assert record[6] == []  # accessors (empty)
 
 
 class TestEventCache:
@@ -1972,7 +2120,7 @@ class TestProviderEnhancements:
         from swarm_provenance_uploader.chain.provider import ChainProvider
 
         provider = ChainProvider(chain="base-sepolia")
-        assert provider.deploy_block == 39_075_766
+        assert provider.deploy_block == 39_905_249
 
 
 class TestProvenanceChainV2StateReads:
@@ -1996,15 +2144,15 @@ class TestProvenanceChainV2StateReads:
             if data_hash == hash_a_bytes:
                 mock_call.call.return_value = (
                     hash_a_bytes, DUMMY_ADDRESS, 1700000000, "swarm-provenance",
-                    [], [], 0,
+                    b"\x00" * 32, [], [], 0,
                 )
             elif data_hash == hash_b_bytes:
                 mock_call.call.return_value = (
                     hash_b_bytes, DUMMY_ADDRESS, 1700000001, "swarm-provenance",
-                    [], [], 0,
+                    b"\x00" * 32, [], [], 0,
                 )
             else:
-                mock_call.call.return_value = (data_hash, ZERO_ADDRESS, 0, "", [], [], 0)
+                mock_call.call.return_value = (data_hash, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0)
             return mock_call
 
         mock_chain_deps["contract"].functions.getDataRecord = mock_get_data_record
@@ -2054,11 +2202,11 @@ class TestProvenanceChainV2StateReads:
         def mock_get_data_record(data_hash):
             mock_call = MagicMock()
             if data_hash == hash_a_bytes:
-                mock_call.call.return_value = (hash_a_bytes, DUMMY_ADDRESS, 1700000000, "type", [], [], 0)
+                mock_call.call.return_value = (hash_a_bytes, DUMMY_ADDRESS, 1700000000, "type", b"\x00" * 32, [], [], 0)
             elif data_hash == hash_b_bytes:
-                mock_call.call.return_value = (hash_b_bytes, DUMMY_ADDRESS, 1700000001, "type", [], [], 0)
+                mock_call.call.return_value = (hash_b_bytes, DUMMY_ADDRESS, 1700000001, "type", b"\x00" * 32, [], [], 0)
             else:
-                mock_call.call.return_value = (data_hash, ZERO_ADDRESS, 0, "", [], [], 0)
+                mock_call.call.return_value = (data_hash, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0)
             return mock_call
 
         mock_chain_deps["contract"].functions.getDataRecord = mock_get_data_record
@@ -2267,7 +2415,7 @@ class TestPreflightBalanceCheck:
 
         # Pre-check: hash not registered (so anchor proceeds to _send_transaction)
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
         )
 
         client = ChainClient(chain="base-sepolia")
@@ -2284,7 +2432,7 @@ class TestPreflightBalanceCheck:
 
         # Pre-check: hash not registered
         mock_chain_deps["contract"].functions.getDataRecord.return_value.call.return_value = (
-            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", [], [], 0,
+            DUMMY_HASH_BYTES, ZERO_ADDRESS, 0, "", b"\x00" * 32, [], [], 0,
         )
 
         # Make send_raw_transaction raise with "insufficient funds" message

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import typer
 from typer.testing import CliRunner
@@ -2879,6 +2880,262 @@ class TestChainAnchorOwner:
             DUMMY_SWARM_REF, owner=owner_addr, data_type="swarm-provenance", storage_ref=None, verbose=False
         )
         mock_client.anchor.assert_not_called()
+
+
+# =============================================================================
+# CHAIN STORAGE REF TESTS (Issue #116)
+# =============================================================================
+
+class TestChainAnchorStorageRef:
+    """Tests for chain anchor --storage-ref option."""
+
+    def test_anchor_with_storage_ref(self, mocker):
+        """Tests chain anchor with --storage-ref passes through correctly."""
+        from swarm_provenance_uploader.models import AnchorResult
+
+        storage_ref = "ee" * 32
+        mock_client = mocker.MagicMock()
+        mock_client.anchor.return_value = AnchorResult(
+            tx_hash=DUMMY_TX_HASH,
+            block_number=100,
+            gas_used=30000,
+            explorer_url=None,
+            swarm_hash=DUMMY_SWARM_REF,
+            data_type="swarm-provenance",
+            owner=DUMMY_ADDRESS,
+            storage_ref=storage_ref,
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(app, [
+            "chain", "anchor", DUMMY_SWARM_REF, "--storage-ref", storage_ref
+        ])
+
+        assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
+        assert "Anchored successfully" in result.stdout
+        assert storage_ref in result.stdout
+        mock_client.anchor.assert_called_once_with(
+            DUMMY_SWARM_REF, data_type="swarm-provenance", storage_ref=storage_ref, verbose=False
+        )
+
+    def test_anchor_with_storage_ref_json(self, mocker):
+        """Tests chain anchor --storage-ref with --json output."""
+        from swarm_provenance_uploader.models import AnchorResult
+
+        storage_ref = "ff" * 32
+        mock_client = mocker.MagicMock()
+        mock_client.anchor.return_value = AnchorResult(
+            tx_hash=DUMMY_TX_HASH,
+            block_number=100,
+            gas_used=30000,
+            explorer_url=None,
+            swarm_hash=DUMMY_SWARM_REF,
+            data_type="swarm-provenance",
+            owner=DUMMY_ADDRESS,
+            storage_ref=storage_ref,
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(app, [
+            "chain", "anchor", DUMMY_SWARM_REF, "--storage-ref", storage_ref, "--json"
+        ])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["storage_ref"] == storage_ref
+
+
+class TestChainSetStorageRef:
+    """Tests for chain set-storage-ref command."""
+
+    def test_set_storage_ref_success(self, mocker):
+        """Tests chain set-storage-ref command."""
+        from swarm_provenance_uploader.models import AnchorResult
+
+        data_hash = "aa" * 32
+        storage_ref = "bb" * 32
+        mock_client = mocker.MagicMock()
+        mock_client.set_storage_ref.return_value = AnchorResult(
+            tx_hash=DUMMY_TX_HASH,
+            block_number=200,
+            gas_used=45000,
+            explorer_url=None,
+            swarm_hash=data_hash,
+            data_type="",
+            owner=DUMMY_ADDRESS,
+            storage_ref=storage_ref,
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(app, ["chain", "set-storage-ref", data_hash, storage_ref])
+
+        assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
+        assert "Storage reference linked" in result.stdout
+        assert data_hash in result.stdout
+        assert storage_ref in result.stdout
+        mock_client.set_storage_ref.assert_called_once_with(data_hash, storage_ref, verbose=False)
+
+    def test_set_storage_ref_json(self, mocker):
+        """Tests chain set-storage-ref with --json output."""
+        from swarm_provenance_uploader.models import AnchorResult
+
+        data_hash = "aa" * 32
+        storage_ref = "bb" * 32
+        mock_client = mocker.MagicMock()
+        mock_client.set_storage_ref.return_value = AnchorResult(
+            tx_hash=DUMMY_TX_HASH,
+            block_number=200,
+            gas_used=45000,
+            explorer_url=None,
+            swarm_hash=data_hash,
+            data_type="",
+            owner=DUMMY_ADDRESS,
+            storage_ref=storage_ref,
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(app, ["chain", "set-storage-ref", data_hash, storage_ref, "--json"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["storage_ref"] == storage_ref
+
+    def test_set_storage_ref_transaction_error(self, mocker):
+        """Tests chain set-storage-ref handles transaction errors."""
+        from swarm_provenance_uploader.exceptions import ChainTransactionError
+
+        mock_client = mocker.MagicMock()
+        mock_client.set_storage_ref.side_effect = ChainTransactionError(
+            "Storage ref already set", tx_hash=DUMMY_TX_HASH
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(app, ["chain", "set-storage-ref", "aa" * 32, "bb" * 32])
+
+        assert result.exit_code == 1
+        assert "Transaction failed" in result.stdout
+
+
+class TestChainLookup:
+    """Tests for chain lookup command."""
+
+    def test_lookup_success(self, mocker):
+        """Tests chain lookup finds a record by storage ref."""
+        from swarm_provenance_uploader.models import ChainProvenanceRecord, DataStatusEnum
+
+        storage_ref = "cc" * 32
+        data_hash = "dd" * 32
+        mock_client = mocker.MagicMock()
+        mock_client.get_by_storage_ref.return_value = ChainProvenanceRecord(
+            data_hash=data_hash,
+            owner=DUMMY_ADDRESS,
+            timestamp=1700000000,
+            data_type="swarm-provenance",
+            storage_ref=storage_ref,
+            status=DataStatusEnum.ACTIVE,
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(app, ["chain", "lookup", storage_ref])
+
+        assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
+        assert "Provenance Record (via storage ref)" in result.stdout
+        mock_client.get_by_storage_ref.assert_called_once_with(storage_ref, verbose=False)
+
+    def test_lookup_not_found(self, mocker):
+        """Tests chain lookup when storage ref is not linked."""
+        from swarm_provenance_uploader.exceptions import DataNotRegisteredError
+
+        storage_ref = "ee" * 32
+        mock_client = mocker.MagicMock()
+        mock_client.get_by_storage_ref.side_effect = DataNotRegisteredError(
+            "Not found", data_hash=storage_ref
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(app, ["chain", "lookup", storage_ref])
+
+        assert result.exit_code == 1
+        assert "Not found" in result.stdout
+
+    def test_lookup_json(self, mocker):
+        """Tests chain lookup with --json output."""
+        from swarm_provenance_uploader.models import ChainProvenanceRecord, DataStatusEnum
+
+        storage_ref = "cc" * 32
+        data_hash = "dd" * 32
+        mock_client = mocker.MagicMock()
+        mock_client.get_by_storage_ref.return_value = ChainProvenanceRecord(
+            data_hash=data_hash,
+            owner=DUMMY_ADDRESS,
+            timestamp=1700000000,
+            data_type="swarm-provenance",
+            storage_ref=storage_ref,
+            status=DataStatusEnum.ACTIVE,
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(app, ["chain", "lookup", storage_ref, "--json"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["data_hash"] == data_hash
+        assert output["storage_ref"] == storage_ref
+
+
+class TestChainGetStorageRef:
+    """Tests for storage_ref display in chain get."""
+
+    def test_get_shows_storage_ref(self, mocker):
+        """Tests that chain get displays storage_ref when present."""
+        from swarm_provenance_uploader.models import ChainProvenanceRecord, DataStatusEnum
+
+        storage_ref = "ff" * 32
+        mock_client = mocker.MagicMock()
+        mock_client.get.return_value = ChainProvenanceRecord(
+            data_hash=DUMMY_SWARM_REF,
+            owner=DUMMY_ADDRESS,
+            timestamp=1700000000,
+            data_type="swarm-provenance",
+            storage_ref=storage_ref,
+            status=DataStatusEnum.ACTIVE,
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(app, ["chain", "get", DUMMY_SWARM_REF])
+
+        assert result.exit_code == 0
+        assert "Storage:" in result.stdout
+
+    def test_get_hides_storage_ref_when_none(self, mocker):
+        """Tests that chain get hides storage_ref when not set."""
+        from swarm_provenance_uploader.models import ChainProvenanceRecord, DataStatusEnum
+
+        mock_client = mocker.MagicMock()
+        mock_client.get.return_value = ChainProvenanceRecord(
+            data_hash=DUMMY_SWARM_REF,
+            owner=DUMMY_ADDRESS,
+            timestamp=1700000000,
+            data_type="swarm-provenance",
+            storage_ref=None,
+            status=DataStatusEnum.ACTIVE,
+        )
+
+        mocker.patch("swarm_provenance_uploader.cli._get_chain_client", return_value=mock_client)
+
+        result = runner.invoke(app, ["chain", "get", DUMMY_SWARM_REF])
+
+        assert result.exit_code == 0
+        assert "Storage:" not in result.stdout
 
 
 # =============================================================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2096,7 +2096,7 @@ class TestChainAnchorCommand:
         result = runner.invoke(app, ["chain", "anchor", DUMMY_SWARM_REF, "--type", "custom-type"])
 
         assert result.exit_code == 0, f"CLI Failed: {result.stdout}"
-        mock_client.anchor.assert_called_once_with(DUMMY_SWARM_REF, data_type="custom-type", verbose=False)
+        mock_client.anchor.assert_called_once_with(DUMMY_SWARM_REF, data_type="custom-type", storage_ref=None, verbose=False)
 
 
 class TestChainAnchorAlreadyRegistered:
@@ -2876,7 +2876,7 @@ class TestChainAnchorOwner:
         assert "Anchored successfully" in result.stdout
         assert owner_addr in result.stdout
         mock_client.anchor_for.assert_called_once_with(
-            DUMMY_SWARM_REF, owner=owner_addr, data_type="swarm-provenance", verbose=False
+            DUMMY_SWARM_REF, owner=owner_addr, data_type="swarm-provenance", storage_ref=None, verbose=False
         )
         mock_client.anchor.assert_not_called()
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1483,6 +1483,140 @@ class TestBlockchainBaseSepolia:
 
 
 # =============================================================================
+# STORAGE REF TESTS (Issue #116)
+# =============================================================================
+
+@pytest.mark.blockchain
+@pytest.mark.slow
+class TestBlockchainStorageRefBaseSepolia:
+    """Integration tests for storageRef on Base Sepolia.
+
+    Requires funded wallet on Base Sepolia.
+    WARNING: Uses real testnet gas.
+    """
+
+    @skip_if_no_chain_wallet
+    @skip_if_no_blockchain_deps
+    def test_anchor_with_storage_ref_base_sepolia(self):
+        """Test anchoring a hash with a storage reference on Base Sepolia."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+        import time
+
+        try:
+            client = ChainClient(chain="base-sepolia")
+
+            data_hash = _random_hash()
+            storage_ref = _random_hash()
+
+            result = client.anchor(
+                swarm_hash=data_hash,
+                data_type="storage-ref-test",
+                storage_ref=storage_ref,
+                verbose=True,
+            )
+
+            print(f"\n=== Anchor with Storage Ref ===")
+            print(f"  Data hash:    {data_hash[:16]}...")
+            print(f"  Storage ref:  {storage_ref[:16]}...")
+            print(f"  Tx:           {result.tx_hash}")
+            print(f"  Gas:          {result.gas_used}")
+
+            assert result.storage_ref == storage_ref
+            assert result.swarm_hash == data_hash
+
+            # Verify the storage ref is on-chain
+            time.sleep(3)
+            record = client.get(data_hash)
+            assert record.storage_ref == storage_ref
+
+            print(f"  On-chain ref: {record.storage_ref[:16]}...")
+
+        except Exception as e:
+            pytest.skip(f"Base Sepolia storage ref anchor test failed: {e}")
+
+    @skip_if_no_chain_wallet
+    @skip_if_no_blockchain_deps
+    def test_set_storage_ref_base_sepolia(self):
+        """Test post-registration storage ref linking on Base Sepolia."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+        import time
+
+        try:
+            client = ChainClient(chain="base-sepolia")
+
+            data_hash = _random_hash()
+            storage_ref = _random_hash()
+
+            # Anchor without storage ref
+            client.anchor(swarm_hash=data_hash, data_type="set-ref-test", verbose=True)
+            time.sleep(3)
+
+            # Verify no storage ref yet
+            record = client.get(data_hash)
+            assert record.storage_ref is None
+
+            # Set storage ref post-registration
+            result = client.set_storage_ref(data_hash, storage_ref, verbose=True)
+            time.sleep(3)
+
+            print(f"\n=== Set Storage Ref ===")
+            print(f"  Data hash:    {data_hash[:16]}...")
+            print(f"  Storage ref:  {storage_ref[:16]}...")
+            print(f"  Tx:           {result.tx_hash}")
+            print(f"  Gas:          {result.gas_used}")
+
+            # Verify it's set
+            record = client.get(data_hash)
+            assert record.storage_ref == storage_ref
+
+        except Exception as e:
+            pytest.skip(f"Base Sepolia set storage ref test failed: {e}")
+
+    @skip_if_no_chain_wallet
+    @skip_if_no_blockchain_deps
+    def test_lookup_by_storage_ref_base_sepolia(self):
+        """Test reverse lookup by storage reference on Base Sepolia."""
+        from swarm_provenance_uploader.core.chain_client import ChainClient
+        from swarm_provenance_uploader.chain.exceptions import DataNotRegisteredError
+        import time
+
+        try:
+            client = ChainClient(chain="base-sepolia")
+
+            data_hash = _random_hash()
+            storage_ref = _random_hash()
+
+            # Anchor with storage ref
+            client.anchor(
+                swarm_hash=data_hash,
+                data_type="lookup-test",
+                storage_ref=storage_ref,
+                verbose=True,
+            )
+            time.sleep(3)
+
+            # Reverse lookup
+            record = client.get_by_storage_ref(storage_ref, verbose=True)
+
+            print(f"\n=== Lookup by Storage Ref ===")
+            print(f"  Storage ref:  {storage_ref[:16]}...")
+            print(f"  Found hash:   {record.data_hash[:16]}...")
+
+            assert record.data_hash == data_hash
+            assert record.storage_ref == storage_ref
+            assert record.data_type == "lookup-test"
+
+            # Verify unknown ref raises error
+            with pytest.raises(DataNotRegisteredError):
+                client.get_by_storage_ref(_random_hash())
+
+        except DataNotRegisteredError:
+            raise  # Let pytest.raises handle it
+        except Exception as e:
+            pytest.skip(f"Base Sepolia lookup test failed: {e}")
+
+
+# =============================================================================
 # MANIFEST / COLLECTION UPLOAD TESTS
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Upgrade to DataProvenance V4 contract (`0x3945aDfd5Df9ab2F5cB4Ca0eb3D4384CC3650322`) with `storageRef` support for bidirectional lookup between content hashes and Swarm storage references
- Add `--storage-ref` option to `chain anchor` command
- Add `chain set-storage-ref` and `chain lookup` commands
- Update ABI, models, contract wrapper, chain client, CLI, docs
- Bump version to 0.10.0

## Test plan

- [x] 648 unit tests pass
- [x] 10 new CLI tests for storageRef commands
- [x] 7 new chain client unit tests for storageRef operations
- [x] 3 new integration tests verified against Base Sepolia V4 contract
- [x] 11/12 existing Base Sepolia integration tests pass (1 transient nonce skip)

Closes #116